### PR TITLE
Add TfL journey planner and refresh page designs

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <div class="hero-card">
         <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo" class="hero-logo" />
         <h1>Welcome to RouteFlow London</h1>
-        <p class="hero-subtitle">London Travel. Reimagined.</p>
+        <p class="hero-subtitle">Plan journeys, track buses and explore London's network.</p>
         <div class="hero-buttons">
           <a class="explore" href="planning.html">Journey Planner</a>
           <a class="learn" href="tracking.html">Arrival Times</a>

--- a/planning.html
+++ b/planning.html
@@ -10,14 +10,21 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Journey Planner</h1>
-  <form id="journey-form">
-    <input type="text" id="from" placeholder="From" required>
-    <input type="text" id="to" placeholder="To" required>
-    <button type="submit">Search</button>
-  </form>
-  <div id="error" class="error"></div>
-  <div id="results"></div>
+  <div id="navbar-container"></div>
+  <section class="page-banner">
+    <h1>Journey Planner</h1>
+    <p>Plan your trip across London using TfL data.</p>
+  </section>
+  <main class="planner">
+    <form id="journey-form" class="planner-form">
+      <input type="text" id="from" placeholder="From" required>
+      <input type="text" id="to" placeholder="To" required>
+      <button type="submit">Search</button>
+    </form>
+    <div id="error" class="error"></div>
+    <div id="results"></div>
+  </main>
   <script src="planning.js"></script>
+  <script src="navbar-loader.js"></script>
 </body>
 </html>

--- a/planning.js
+++ b/planning.js
@@ -34,8 +34,24 @@ document.getElementById('journey-form').addEventListener('submit', async (e) => 
 
     data.journeys.forEach((journey, index) => {
       const option = document.createElement('div');
+      option.className = 'journey-option';
+
       const interchanges = journey.legs ? journey.legs.length - 1 : 0;
-      option.textContent = `Option ${index + 1}: ${journey.duration} mins, ${interchanges} interchange${interchanges === 1 ? '' : 's'}`;
+      const header = document.createElement('h3');
+      header.textContent = `Option ${index + 1} – ${journey.duration} mins (${interchanges} interchange${interchanges === 1 ? '' : 's'})`;
+      option.appendChild(header);
+
+      const legsList = document.createElement('ol');
+      journey.legs.forEach(leg => {
+        const li = document.createElement('li');
+        const mode = leg.mode?.name || leg.modeName;
+        const departure = leg.departurePoint?.commonName || '';
+        const arrival = leg.arrivalPoint?.commonName || '';
+        const line = leg.routeOptions && leg.routeOptions[0] ? ` (${leg.routeOptions[0].name})` : '';
+        li.textContent = `${mode}${line}: ${departure} → ${arrival}`;
+        legsList.appendChild(li);
+      });
+      option.appendChild(legsList);
       resultsDiv.appendChild(option);
     });
   } catch (err) {

--- a/routes.html
+++ b/routes.html
@@ -108,6 +108,10 @@
     </div>
   </div>
 </header>
+<section class="page-banner">
+  <h1>Routes</h1>
+  <p>Browse active London bus routes.</p>
+</section>
 
 <style>
 .navbar {

--- a/style.css
+++ b/style.css
@@ -297,8 +297,22 @@ body.dark-mode .modal-content input {
   align-items: center;
   justify-content: center;
   min-height: 57vh;
-  background: linear-gradient(135deg, var(--primary) 0%, var(--accent-blue) 100%);
+  background: linear-gradient(135deg, var(--accent-blue) 0%, var(--primary) 100%);
   padding: 5vw 0;
+}
+.page-banner {
+  background: linear-gradient(135deg, var(--accent-blue), var(--primary));
+  color: #fff;
+  text-align: center;
+  padding: 3rem 1rem;
+}
+.page-banner h1 {
+  margin: 0;
+  font-size: 2.5rem;
+}
+.page-banner p {
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
 }
 .hero-card {
   background: var(--card-bg-light);
@@ -717,6 +731,44 @@ body.dark-mode button:hover,
 body.dark-mode .btn:hover {
   background: var(--primary-dark);
 }
+
+/* Journey planner layout */
+.planner {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+.planner-form {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+.planner-form input {
+  flex: 1;
+}
+.planner-form button {
+  background: var(--accent-blue);
+  color: #fff;
+  border: none;
+  padding: 0.8rem 1.2rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.planner .error {
+  color: var(--primary);
+  margin-top: 1rem;
+}
+.journey-option {
+  background: var(--card-bg-light);
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: var(--border-radius);
+}
+body.dark-mode .journey-option {
+  background: var(--card-bg-dark);
+}
+.journey-option h3 { margin-top: 0; }
+.journey-option ol { padding-left: 1.2rem; }
 
 /*-------------------------------
   Responsive Design

--- a/withdrawn.html
+++ b/withdrawn.html
@@ -3,97 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
+  <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
   <title>Withdrawn Routes | Routeflow London</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="stylesheet" href="style.css">
-<head>
-<body>
-  <div id="navbar-container"></div>
-
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="style.css" />
   <style>
-    /* Enhanced search and filter styling */
-    .filters-container {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin: 20px auto;
-      justify-content: center;
-    }
-    .filters-container input, .filters-container select {
-      padding: 8px;
-      border-radius: 12px;
-      border: 1px solid #ccc;
-      font-size: 1rem;
-    }
-    table.bubble-table-lined {
-      border-collapse: collapse;
-      width: 100%;
-      border-radius: 15px;
-      overflow: hidden;
-      box-shadow: 0 0 15px rgba(0,0,0,0.1);
-    }
-    table.bubble-table-lined th, table.bubble-table-lined td {
-      padding: 10px;
-      border: 1px solid #e0e0e0;
-      text-align: left;
-    }
-    table.bubble-table-lined thead {
-      background-color: #f5f5f5;
-    }
-    #searchInput {
-      width: 50%;
-      padding: 10px;
-      font-size: 1rem;
-      border-radius: 20px;
-      border: 1px solid #ccc;
-      margin-bottom: 20px;
-    }
-  </style>
-  <main style="padding: 3rem 1rem; text-align: center;">
-    <h1>Withdrawn Routes</h1>
-    <p>Explore London's discontinued bus routes using advanced filters below.</p>
-    
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
-
-    body {
-      font-family: 'Segoe UI', Arial, sans-serif;
-      background-color: #f7f8fa;
-      padding: 2vw;
-      color: #2d3a4a;
-    }
-
-    h1 {
-      text-align: center;
-      margin-bottom: 24px;
-      font-size: 2em;
-    }
-
     .controls {
       max-width: 95vw;
-      margin: 0 auto 20px auto;
+      margin: 0 auto 20px;
       text-align: center;
     }
-
-    input[type="text"] {
+    .controls input {
       padding: 10px;
       width: 250px;
       border-radius: 6px;
       border: 1px solid #ccc;
       margin-bottom: 10px;
     }
-
     .table-container {
       max-width: 95vw;
       margin: auto;
@@ -103,69 +30,35 @@
       box-shadow: 0 2px 12px rgba(0,0,0,0.1);
       padding: 16px;
     }
-
     table {
       width: 100%;
       border-collapse: collapse;
       min-width: 700px;
     }
-
     th, td {
       padding: 12px;
       text-align: center;
       border-bottom: 1px solid #e0e0e0;
     }
-
     th {
       background: linear-gradient(90deg, #2d3a4a 80%, #3f4e62 100%);
       color: white;
       font-weight: bold;
     }
-
-    tr:hover td {
-      background-color: #f1f6fb;
-    }
-
+    tr:hover td { background-color: #f1f6fb; }
     @media (max-width: 768px) {
-      body {
-        padding: 8px;
-      }
-
-      th, td {
-        padding: 8px;
-        font-size: 0.9em;
-      }
-
-      h1 {
-        font-size: 1.5em;
-      }
+      th, td { padding: 8px; font-size: 0.9em; }
     }
   </style>
-  <script>
-    function filterTable() {
-      const input = document.getElementById("searchInput");
-      const filter = input.value.toLowerCase();
-      const table = document.getElementById("routeTable");
-      const tr = table.getElementsByTagName("tr");
-
-      for (let i = 1; i < tr.length; i++) {
-        let tdMatch = false;
-        const tds = tr[i].getElementsByTagName("td");
-        for (let j = 0; j < tds.length; j++) {
-          if (tds[j] && tds[j].textContent.toLowerCase().includes(filter)) {
-            tdMatch = true;
-            break;
-          }
-        }
-        tr[i].style.display = tdMatch ? "" : "none";
-      }
-    }
-  </script>
 </head>
 <body>
-  <h1>Withdrawn London Bus Routes</h1>
+  <div id="navbar-container"></div>
+  <section class="page-banner">
+    <h1>Withdrawn Routes</h1>
+    <p>Explore London's discontinued bus routes.</p>
+  </section>
   <div class="controls">
-    <input type="text" id="searchInput" onkeyup="filterTable()" placeholder="Search routes, locations, operators...">
+    <input type="text" id="searchInput" onkeyup="filterTable()" placeholder="Search routes, locations, operators..." />
   </div>
   <div class="table-container">
     <table id="routeTable">
@@ -3784,6 +3677,25 @@
 </tbody>
 </table>
   </div>
+  <script>
+    function filterTable() {
+      const input = document.getElementById('searchInput');
+      const filter = input.value.toLowerCase();
+      const table = document.getElementById('routeTable');
+      const tr = table.getElementsByTagName('tr');
+      for (let i = 1; i < tr.length; i++) {
+        let tdMatch = false;
+        const tds = tr[i].getElementsByTagName('td');
+        for (let j = 0; j < tds.length; j++) {
+          if (tds[j] && tds[j].textContent.toLowerCase().includes(filter)) {
+            tdMatch = true;
+            break;
+          }
+        }
+        tr[i].style.display = tdMatch ? '' : 'none';
+      }
+    }
+  </script>
   <script src="navbar-loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update landing hero and add reusable banner section for a consistent look
- clean up withdrawn routes and routes pages with new banner
- implement Journey Planner powered by TfL API with detailed leg results

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c7bc065bbc8322bab23444e936b06f