### PR TITLE
Add recents list to dashboard and allow removing favourites

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -56,6 +56,31 @@ body.dark-mode .activity-list li { border-color: #444; }
   text-align: center;
 }
 body.dark-mode .favourite-item { background: var(--card-bg-dark); }
+.favourite-item button {
+  margin-top: 0.5rem;
+  background: var(--accent-blue);
+  color: #fff;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.favourite-item button:hover {
+  background: var(--accent-blue-dark);
+}
+
+.recents-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.recents-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #ddd;
+}
+body.dark-mode .recents-list li { border-color: #444; }
 .setting-item {
   display: flex;
   align-items: center;

--- a/dashboard.html
+++ b/dashboard.html
@@ -30,6 +30,10 @@
         <h2>Your Favourites</h2>
         <div id="favouritesGrid" class="favourites-grid"></div>
       </section>
+      <section class="card">
+        <h2>Recents</h2>
+        <ul id="recentsList" class="recents-list"></ul>
+      </section>
     </div>
   </main>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
@@ -50,7 +54,8 @@
   <script src="theme.js"></script>
   <script src="navbar-loader.js"></script>
   <script type="module">
-    import {getFavourites} from './favourites.js';
+    import {getFavourites, removeFavourite} from './favourites.js';
+    import {getRecents} from './recents.js';
 
     window.signOut = () => { firebase.auth().signOut(); };
     window.openModal = () => {};
@@ -67,7 +72,32 @@
         const div = document.createElement('div');
         div.className = 'favourite-item';
         div.innerHTML = `<h3>${f.type}</h3><p>${f.value}</p>`;
+        const btn = document.createElement('button');
+        btn.textContent = 'Remove';
+        btn.addEventListener('click', () => {
+          removeFavourite(uid, f.id);
+          loadFavourites(uid);
+        });
+        div.appendChild(btn);
         grid.appendChild(div);
+      });
+    }
+
+    function loadRecents(uid) {
+      const list = document.getElementById('recentsList');
+      list.innerHTML = '';
+      const recents = getRecents(uid);
+      if (recents.length === 0) {
+        list.innerHTML = '<li>No recent items.</li>';
+        return;
+      }
+      recents.forEach(r => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = r.url;
+        a.textContent = r.title || r.url;
+        li.appendChild(a);
+        list.appendChild(li);
       });
     }
 
@@ -96,12 +126,14 @@
         info.textContent = '';
         loadFavourites(user.uid);
         loadActivity(user.uid);
+        loadRecents(user.uid);
       } else {
         title.textContent = 'Welcome';
         avatar.src = 'user-icon.png';
         info.textContent = 'Please sign in to see your data.';
         document.getElementById('favouritesGrid').innerHTML = '<p>Sign in to manage favourites.</p>';
         document.getElementById('activityList').innerHTML = '<li>Sign in to see activity.</li>';
+        loadRecents('guest');
       }
     });
   </script>

--- a/recents.js
+++ b/recents.js
@@ -1,0 +1,21 @@
+export function getRecents(uid) {
+  try {
+    const data = localStorage.getItem(`recents_${uid}`);
+    return data ? JSON.parse(data) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+export function saveRecents(uid, recents) {
+  localStorage.setItem(`recents_${uid}`, JSON.stringify(recents));
+}
+
+export function addRecent(uid, item) {
+  const recents = getRecents(uid);
+  // remove existing entry with same id or url if present
+  const filtered = recents.filter(r => r.id !== item.id && r.url !== item.url);
+  filtered.unshift(item); // add to start
+  // keep only last 10
+  saveRecents(uid, filtered.slice(0, 10));
+}


### PR DESCRIPTION
## Summary
- Display recent items on dashboard via new `recents.js` module
- Allow removing favourites directly from the dashboard
- Style recents list and favourite controls

## Testing
- `node --check recents.js`
- `node --check favourites.js`


------
https://chatgpt.com/codex/tasks/task_e_68c7be8fb18c83228535e57ac3be5037