### PR TITLE
Add journey planner map and advanced filters

### DIFF
--- a/planning.html
+++ b/planning.html
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
 <body>
   <div id="navbar-container"></div>
@@ -19,11 +20,47 @@
     <form id="journey-form" class="planner-form">
       <input type="text" id="from" placeholder="From" required>
       <input type="text" id="to" placeholder="To" required>
+      <fieldset class="filters">
+        <legend>Modes</legend>
+        <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
+        <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
+        <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
+        <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
+        <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
+        <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
+        <label><input type="checkbox" name="mode" value="national-rail" checked> National Rail</label>
+        <label><input type="checkbox" name="mode" value="coach" checked> Coach</label>
+        <label><input type="checkbox" name="mode" value="cable-car" checked> Cable Car</label>
+        <label><input type="checkbox" name="mode" value="cycle" checked> Cycle</label>
+      </fieldset>
+      <fieldset class="filters">
+        <legend>Accessibility</legend>
+        <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
+        <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
+        <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
+        <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
+        <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
+        <label><input type="checkbox" name="accessibility" value="NoNarrowGates"> No narrow gates</label>
+        <label><input type="checkbox" name="accessibility" value="TurnUpAndGo"> Turn up and go</label>
+      </fieldset>
+      <div class="walking-options">
+        <label for="walking-speed">Walking speed:</label>
+        <select id="walking-speed">
+          <option value="">Default</option>
+          <option value="slow">Slow</option>
+          <option value="average">Average</option>
+          <option value="fast">Fast</option>
+        </select>
+        <label for="max-walking">Max walking (mins):</label>
+        <input type="number" id="max-walking" min="1" max="60">
+      </div>
       <button type="submit">Search</button>
     </form>
     <div id="error" class="error"></div>
     <div id="results"></div>
+    <div id="map" class="planner-map"></div>
   </main>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="planning.js"></script>
   <script src="navbar-loader.js"></script>
 </body>

--- a/planning.js
+++ b/planning.js
@@ -1,5 +1,40 @@
 // Journey planning logic for Routeflow London
 
+let map;
+let journeyLayers = [];
+
+function initMap() {
+  if (!map) {
+    map = L.map('map').setView([51.505, -0.09], 11);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors',
+    }).addTo(map);
+  }
+}
+
+function drawJourney(journey) {
+  initMap();
+  journeyLayers.forEach((layer) => map.removeLayer(layer));
+  journeyLayers = [];
+  const bounds = [];
+  if (Array.isArray(journey.legs)) {
+    journey.legs.forEach((leg) => {
+      if (leg.path && leg.path.lineString) {
+        const coords = leg.path.lineString.split(' ').map((p) => {
+          const [lng, lat] = p.split(',').map(Number);
+          const c = [lat, lng];
+          bounds.push(c);
+          return c;
+        });
+        journeyLayers.push(
+          L.polyline(coords, { color: '#2979ff' }).addTo(map)
+        );
+      }
+    });
+  }
+  if (bounds.length) map.fitBounds(bounds);
+}
+
 document.getElementById('journey-form').addEventListener('submit', async (e) => {
   e.preventDefault();
 
@@ -7,6 +42,14 @@ document.getElementById('journey-form').addEventListener('submit', async (e) => 
   const to = document.getElementById('to').value.trim();
   const resultsDiv = document.getElementById('results');
   const errorDiv = document.getElementById('error');
+  const mode = Array.from(
+    document.querySelectorAll('input[name="mode"]:checked')
+  ).map((cb) => cb.value);
+  const accessibility = Array.from(
+    document.querySelectorAll('input[name="accessibility"]:checked')
+  ).map((cb) => cb.value);
+  const walkingSpeed = document.getElementById('walking-speed').value;
+  const maxWalking = document.getElementById('max-walking').value;
 
   resultsDiv.innerHTML = '';
   errorDiv.textContent = '';
@@ -17,7 +60,17 @@ document.getElementById('journey-form').addEventListener('submit', async (e) => 
   }
 
   try {
-    const url = `https://api.tfl.gov.uk/Journey/JourneyResults/${encodeURIComponent(from)}/to/${encodeURIComponent(to)}`;
+    const params = new URLSearchParams();
+    if (mode.length) params.append('mode', mode.join(','));
+    accessibility.forEach((pref) =>
+      params.append('accessibilityPreference', pref)
+    );
+    if (walkingSpeed) params.append('walkingSpeed', walkingSpeed);
+    if (maxWalking) params.append('maxWalkingMinutes', maxWalking);
+
+    let url = `https://api.tfl.gov.uk/Journey/JourneyResults/${encodeURIComponent(from)}/to/${encodeURIComponent(to)}`;
+    if (params.toString()) url += `?${params.toString()}`;
+
     const res = await fetch(url);
     if (!res.ok) {
       if (res.status === 404) {
@@ -36,24 +89,47 @@ document.getElementById('journey-form').addEventListener('submit', async (e) => 
       const option = document.createElement('div');
       option.className = 'journey-option';
 
-      const interchanges = journey.legs ? journey.legs.length - 1 : 0;
+      const interchanges = Array.isArray(journey.legs)
+        ? journey.legs.length - 1
+        : 0;
       const header = document.createElement('h3');
-      header.textContent = `Option ${index + 1} – ${journey.duration} mins (${interchanges} interchange${interchanges === 1 ? '' : 's'})`;
+      const plural = interchanges === 1 ? '' : 's';
+      header.textContent = `Option ${index + 1} – ${journey.duration} mins (${interchanges} interchange${plural})`;
       option.appendChild(header);
 
-      const legsList = document.createElement('ol');
-      journey.legs.forEach(leg => {
-        const li = document.createElement('li');
-        const mode = leg.mode?.name || leg.modeName;
-        const departure = leg.departurePoint?.commonName || '';
-        const arrival = leg.arrivalPoint?.commonName || '';
-        const line = leg.routeOptions && leg.routeOptions[0] ? ` (${leg.routeOptions[0].name})` : '';
-        li.textContent = `${mode}${line}: ${departure} → ${arrival}`;
-        legsList.appendChild(li);
-      });
-      option.appendChild(legsList);
+      if (Array.isArray(journey.legs)) {
+        const legsList = document.createElement('ol');
+        journey.legs.forEach((leg) => {
+          const li = document.createElement('li');
+          const modeName = leg.mode?.name || leg.modeName;
+          const departure = leg.departurePoint?.commonName || '';
+          const arrival = leg.arrivalPoint?.commonName || '';
+          const line =
+            leg.routeOptions && leg.routeOptions[0]
+              ? ` (${leg.routeOptions[0].name})`
+              : '';
+          const departTime = leg.departureTime
+            ? new Date(leg.departureTime).toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })
+            : '';
+          const arriveTime = leg.arrivalTime
+            ? new Date(leg.arrivalTime).toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })
+            : '';
+          const timeStr = departTime && arriveTime ? ` (${departTime}–${arriveTime})` : '';
+          li.textContent = `${modeName}${line}: ${departure} → ${arrival}${timeStr}`;
+          legsList.appendChild(li);
+        });
+        option.appendChild(legsList);
+      }
+      option.addEventListener('click', () => drawJourney(journey));
       resultsDiv.appendChild(option);
     });
+    drawJourney(data.journeys[0]);
   } catch (err) {
     errorDiv.textContent = 'Unable to fetch journeys. Please check your search and try again.';
     console.error(err);

--- a/style.css
+++ b/style.css
@@ -768,6 +768,36 @@ body.dark-mode .journey-option {
   background: var(--card-bg-dark);
 }
 .journey-option h3 { margin-top: 0; }
+.journey-option ol {
+  margin: 0.5rem 0 0 1.2rem;
+}
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.filters label {
+  flex: 1 0 150px;
+}
+.walking-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+.walking-options label {
+  flex: 1 0 140px;
+}
+.walking-options select,
+.walking-options input {
+  flex: 1 0 120px;
+}
+.planner-map {
+  height: 400px;
+  margin-top: 1rem;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
 .journey-option ol { padding-left: 1.2rem; }
 
 /*-------------------------------


### PR DESCRIPTION
## Summary
- expand planner form with more mode and accessibility filters plus walking controls
- style planner layout and embed Leaflet map to visualise routes
- update planning logic to send new parameters, show leg times and draw paths on map

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check planning.js`


------
https://chatgpt.com/codex/tasks/task_e_68c810ea80448322b8c111fb718735ce