### PR TITLE
Ensure authentication modal works across the site

### DIFF
--- a/components/auth-modal.html
+++ b/components/auth-modal.html
@@ -1,0 +1,72 @@
+<div id="authModal" class="auth-modal" role="dialog" aria-modal="true" aria-hidden="true">
+  <div class="auth-modal__dialog" role="document">
+    <button type="button" class="auth-modal__close" id="closeModal" aria-label="Close authentication dialog">
+      <span aria-hidden="true">&times;</span>
+    </button>
+
+    <div class="auth-modal__panel" id="loginFormContainer">
+      <h2 class="auth-modal__title">Welcome back</h2>
+      <p class="auth-modal__subtitle">Sign in to see favourites, recents, and personalised alerts.</p>
+      <form id="loginForm" class="auth-modal__form" autocomplete="off">
+        <label class="auth-modal__field" for="loginEmail">
+          <span>Email</span>
+          <input type="email" id="loginEmail" name="loginEmail" required autocomplete="username" />
+        </label>
+        <label class="auth-modal__field" for="loginPassword">
+          <span>Password</span>
+          <input type="password" id="loginPassword" name="loginPassword" required autocomplete="current-password" />
+        </label>
+        <button type="submit" class="auth-modal__primary">Log in</button>
+        <button type="button" class="auth-modal__provider google-btn google-login">Continue with Google</button>
+        <div class="auth-modal__error" id="loginError" role="alert" hidden></div>
+      </form>
+      <p class="auth-modal__links">
+        <a href="#" id="showReset" class="auth-modal__link">Forgot password?</a>
+      </p>
+      <p class="auth-modal__switch">
+        Don't have an account?
+        <a href="#" id="showSignup" class="auth-modal__link">Create one</a>
+      </p>
+    </div>
+
+    <div class="auth-modal__panel" id="signupFormContainer" hidden>
+      <h2 class="auth-modal__title">Join RouteFlow London</h2>
+      <p class="auth-modal__subtitle">Create an account to sync favourites and preferences everywhere.</p>
+      <form id="signupForm" class="auth-modal__form" autocomplete="off">
+        <label class="auth-modal__field" for="signupEmail">
+          <span>Email</span>
+          <input type="email" id="signupEmail" name="signupEmail" required autocomplete="username" />
+        </label>
+        <label class="auth-modal__field" for="signupPassword">
+          <span>Password</span>
+          <input type="password" id="signupPassword" name="signupPassword" required autocomplete="new-password" />
+        </label>
+        <button type="submit" class="auth-modal__primary">Sign up</button>
+        <button type="button" class="auth-modal__provider google-btn google-login">Sign up with Google</button>
+        <div class="auth-modal__error" id="signupError" role="alert" hidden></div>
+      </form>
+      <p class="auth-modal__switch">
+        Already have an account?
+        <a href="#" id="showLogin" class="auth-modal__link">Log in</a>
+      </p>
+    </div>
+
+    <div class="auth-modal__panel" id="resetFormContainer" hidden>
+      <h2 class="auth-modal__title">Reset password</h2>
+      <p class="auth-modal__subtitle">We'll email you a link to set a new password.</p>
+      <form id="resetForm" class="auth-modal__form" autocomplete="off">
+        <label class="auth-modal__field" for="resetEmail">
+          <span>Email</span>
+          <input type="email" id="resetEmail" name="resetEmail" required autocomplete="email" />
+        </label>
+        <button type="submit" class="auth-modal__primary">Send reset link</button>
+        <div class="auth-modal__message" id="resetSuccess" role="status" hidden></div>
+        <div class="auth-modal__error" id="resetError" role="alert" hidden></div>
+      </form>
+      <p class="auth-modal__switch">
+        Remembered your password?
+        <a href="#" id="showLoginFromReset" class="auth-modal__link">Back to log in</a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/style.css
+++ b/style.css
@@ -819,6 +819,218 @@ body.dark-mode .journey-option {
 .journey-option ol { padding-left: 1.2rem; }
 
 /*-------------------------------
+  Authentication Modal
+-------------------------------*/
+body[data-auth-modal-open="true"] {
+  overflow: hidden;
+}
+
+#authModal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1500;
+  padding: 1.5rem;
+  background: rgba(17, 24, 39, 0.55);
+  backdrop-filter: blur(2px);
+  align-items: center;
+  justify-content: center;
+}
+
+#authModal[data-open="true"] {
+  display: flex;
+}
+
+.auth-modal__dialog {
+  position: relative;
+  width: min(420px, 100%);
+  background: var(--background-light);
+  color: var(--foreground-light);
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.22);
+  padding: 2rem 2rem 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body.dark-mode #authModal .auth-modal__dialog {
+  background: #1f2937;
+  color: var(--foreground-dark);
+}
+
+.auth-modal__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.auth-modal__close:hover {
+  transform: scale(1.05);
+  color: var(--accent-blue);
+}
+
+.auth-modal__panel[hidden] {
+  display: none;
+}
+
+.auth-modal__title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.auth-modal__subtitle {
+  margin: 0;
+  font-size: 0.98rem;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+body.dark-mode #authModal .auth-modal__subtitle {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.auth-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-top: 0.75rem;
+}
+
+.auth-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.auth-modal__field input {
+  border-radius: 10px;
+  border: 1.5px solid rgba(15, 23, 42, 0.15);
+  padding: 0.75rem 0.9rem;
+  font-size: 1rem;
+  background: var(--background-light);
+  color: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.dark-mode #authModal .auth-modal__field input {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.auth-modal__field input:focus {
+  outline: none;
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 3px rgba(41, 121, 255, 0.25);
+}
+
+.auth-modal__primary,
+.auth-modal__provider {
+  border-radius: 10px;
+  padding: 0.85rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.auth-modal__primary {
+  background: var(--accent-blue);
+  color: #fff;
+  border: none;
+}
+
+.auth-modal__primary:hover {
+  background: var(--accent-blue-dark);
+  transform: translateY(-1px);
+}
+
+.auth-modal__provider {
+  background: #fff;
+  color: #1f2933;
+  border: 1.5px solid rgba(15, 23, 42, 0.12);
+}
+
+.auth-modal__provider:hover {
+  background: rgba(15, 23, 42, 0.04);
+  color: #0f172a;
+  transform: translateY(-1px);
+}
+
+body.dark-mode #authModal .auth-modal__provider {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.auth-modal__error,
+.auth-modal__message {
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.auth-modal__error {
+  background: rgba(211, 47, 47, 0.1);
+  color: #b71c1c;
+  border-left: 4px solid #d32f2f;
+}
+
+body.dark-mode #authModal .auth-modal__error {
+  background: rgba(239, 83, 80, 0.18);
+  color: #ffb3b8;
+  border-color: rgba(239, 83, 80, 0.6);
+}
+
+.auth-modal__message {
+  background: rgba(46, 125, 50, 0.12);
+  color: #1b5e20;
+  border-left: 4px solid #2e7d32;
+}
+
+body.dark-mode #authModal .auth-modal__message {
+  background: rgba(129, 199, 132, 0.18);
+  color: #c8facc;
+  border-color: rgba(129, 199, 132, 0.6);
+}
+
+.auth-modal__links,
+.auth-modal__switch {
+  font-size: 0.95rem;
+  margin: 0;
+  text-align: center;
+}
+
+.auth-modal__link {
+  color: var(--accent-blue);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.auth-modal__link:hover {
+  text-decoration: underline;
+}
+
+body.dark-mode #authModal .auth-modal__link {
+  color: #90c2ff;
+}
+
+@media (max-width: 520px) {
+  .auth-modal__dialog {
+    padding: 1.6rem 1.4rem 1.4rem;
+  }
+}
+
+/*-------------------------------
   Responsive Design
 -------------------------------*/
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- add a shared authentication modal component and corresponding styles
- load Firebase/auth scripts and the modal from the navbar loader so login buttons work on every page
- harden the main authentication logic with error handling, password reset support, and global dropdown updates

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c95ac110dc8322b091293d7390c108