### PR TITLE
Redesign landing and tracking pages with admin-managed blog

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,554 +6,93 @@
   <title>Blog - RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png" />
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
   <script src="theme.js" defer></script>
 </head>
 <body>
-  <header class="navbar">
-  <div class="navbar__container">
-    <a href="index.html" class="navbar__logo" aria-label="RouteFlow London Home">
-      <img src="images/Routeflow London permanent logo.png" alt="RouteFlow London Logo" />
-      <strong>RouteFlow London</strong>
-    </a>
-    <nav class="navbar__links" id="navbarLinks">
-      <a href="index.html">Home</a>
-      <a href="dashboard.html">Dashboard</a>
-      <a href="tracking.html">Tracking</a>
-      <a href="planning.html">Planning</a>
-      <a href="routes.html">Routes</a>
-      <a href="withdrawn.html">Withdrawn</a>
-      <a href="disruptions.html">Disruptions</a>
-      <a href="fleet.html">Fleet</a>
-    </nav>
-    <div class="navbar__controls">
-      <button class="hamburger" id="hamburgerBtn" aria-label="Open mobile menu">
-        <i class="fa-solid fa-bars"></i>
-      </button>
-      <div class="account-menu" id="accountMenu">
-        <button aria-label="Account" id="profileIcon" type="button">
-          <i class="fa-regular fa-user"></i>
-        </button>
-        <div class="account-dropdown" id="dropdownContent">
-          <a href="profile.html">Profile</a>
-          <a href="settings.html">Settings</a>
-          <button onclick="openModal('login')" type="button">Login</button>
-          <button onclick="openModal('signup')" type="button">Sign Up</button>
-          <button onclick="signOut()" type="button">Sign out</button>
+  <div id="navbar-container"></div>
+
+  <main class="blog-shell">
+    <section class="blog-hero card">
+      <p class="blog-hero__eyebrow">RouteFlow stories</p>
+      <h1>Updates, release notes and deep dives into London&#39;s network.</h1>
+      <p>Everything published here is managed directly from the admin console, so it&#39;s easy to keep the community informed.</p>
+      <div class="blog-hero__meta">
+        <div>
+          <span class="blog-hero__label">Latest update</span>
+          <time id="blogLatestDate">—</time>
+        </div>
+        <div>
+          <span class="blog-hero__label">Total posts</span>
+          <strong id="blogTotalPosts">0</strong>
         </div>
       </div>
-    </div>
-  </div>
-  <!-- Mobile nav drawer -->
-  <nav class="mobile-drawer" id="mobileDrawer" aria-label="Mobile Navigation">
-    <button class="close-drawer" id="closeDrawerBtn" aria-label="Close menu">
-      <i class="fa-solid fa-times"></i>
-    </button>
-    <a href="index.html">Home</a>
-    <a href="dashboard.html">Dashboard</a>
-    <a href="tracking.html">Tracking</a>
-    <a href="planning.html">Planning</a>
-    <a href="routes.html">Routes</a>
-    <a href="withdrawn.html">Withdrawn</a>
-    <a href="disruptions.html">Disruptions</a>
-    <a href="fleet.html">Fleet</a>
-    <hr>
-    <a href="profile.html">Profile</a>
-    <a href="settings.html">Settings</a>
-    <button onclick="openModal('login')" type="button">Login</button>
-    <button onclick="openModal('signup')" type="button">Sign Up</button>
-    <button onclick="signOut()" type="button">Sign out</button>
-  </nav>
-  <div class="drawer-backdrop" id="drawerBackdrop"></div>
+    </section>
 
-  <!-- Modal for login/signup/reset -->
-  <div id="authModal" class="modal" aria-modal="true" role="dialog">
-    <div class="modal-content">
-      <span class="close" id="closeModal" title="Close">&times;</span>
-      <!-- Login Form -->
-      <div id="loginFormContainer">
-        <h2>Login</h2>
-        <form id="loginForm" autocomplete="off">
-          <input type="email" id="loginEmail" placeholder="Email" required autocomplete="username">
-          <input type="password" id="loginPassword" placeholder="Password" required autocomplete="current-password">
-          <button type="submit">Login</button>
-          <button type="button" class="google-btn">Sign in with Google</button>
-          <p><a href="#" class="reset-password" id="showReset">Forgot Password?</a></p>
-          <div class="error-message" id="loginError" style="display:none;"></div>
-        </form>
-        <p>Don't have an account? <a href="#" id="showSignup">Sign up</a></p>
+    <section class="blog-list card">
+      <div class="blog-list__header">
+        <h2>All posts</h2>
+        <p>Catch every announcement, improvement and behind-the-scenes look at RouteFlow London.</p>
       </div>
-      <!-- Signup Form -->
-      <div id="signupFormContainer" style="display:none;">
-        <h2>Sign Up</h2>
-        <form id="signupForm" autocomplete="off">
-          <input type="email" id="signupEmail" placeholder="Email" required autocomplete="username">
-          <input type="password" id="signupPassword" placeholder="Password" required autocomplete="new-password">
-          <button type="submit">Sign Up</button>
-          <button type="button" class="google-btn">Sign Up with Google</button>
-          <div class="error-message" id="signupError" style="display:none;"></div>
-        </form>
-        <p>Already have an account? <a href="#" id="showLogin">Login</a></p>
-      </div>
-      <!-- Reset Password Form -->
-      <div id="resetFormContainer" style="display:none;">
-        <h2>Reset Password</h2>
-        <form id="resetForm" autocomplete="off">
-          <input type="email" id="resetEmail" placeholder="Enter your email" required autocomplete="username">
-          <button type="submit">Send Reset Link</button>
-          <div class="error-message" id="resetError" style="display:none;"></div>
-        </form>
-        <p>Remembered? <a href="#" id="showLoginFromReset">Back to Login</a></p>
-      </div>
-    </div>
-  </div>
-</header>
+      <div class="blog-list__grid" data-blog-list data-blog-variant="full" data-blog-empty="No blog posts published yet."></div>
+    </section>
+  </main>
 
-<style>
-.navbar {
-  background: #fff;
-  border-bottom: 1px solid #e5e5e5;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  font-family: 'Segoe UI', Arial, sans-serif;
-}
-
-.navbar__container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.7rem 2vw;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.2rem;
-}
-
-.navbar__logo {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  text-decoration: none;
-  color: #c62828;
-}
-.navbar__logo img {
-  height: 38px;
-}
-.navbar__logo strong {
-  font-size: 1.25rem;
-  font-weight: bold;
-  letter-spacing: 1px;
-}
-
-/* Desktop nav links */
-.navbar__links {
-  display: flex;
-  gap: 1rem;
-}
-.navbar__links a {
-  color: #333;
-  text-decoration: none;
-  padding: 0.45rem 0.9rem;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 1.05rem;
-  transition: background .18s, color .18s;
-}
-.navbar__links a.active,
-.navbar__links a:hover {
-  background: #2979ff;
-  color: #fff;
-}
-
-.navbar__controls {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-/* Hamburger button */
-.hamburger {
-  background: none;
-  border: none;
-  font-size: 1.55rem;
-  color: #c62828;
-  cursor: pointer;
-  display: none;
-}
-.account-menu {
-  position: relative;
-}
-.account-menu button {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: #333;
-  padding: 0.15rem 0.4rem;
-  border-radius: 50%;
-  cursor: pointer;
-  transition: background 0.17s;
-}
-.account-menu button:hover {
-  background: #f0f0f0;
-}
-.account-dropdown {
-  display: none;
-  flex-direction: column;
-  position: absolute;
-  right: 0;
-  top: 125%;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 4px 18px #0002;
-  min-width: 150px;
-  z-index: 10;
-  padding: 0.5rem 0;
-}
-.account-dropdown a,
-.account-dropdown button {
-  background: none;
-  border: none;
-  color: #333;
-  padding: 0.7rem 1rem;
-  text-align: left;
-  text-decoration: none;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.16s;
-}
-.account-dropdown a:hover,
-.account-dropdown button:hover {
-  background: #2979ff;
-  color: #fff;
-}
-.account-menu.open .account-dropdown {
-  display: flex;
-}
-
-/* Mobile Nav Drawer */
-.mobile-drawer {
-  display: flex;
-  flex-direction: column;
-  position: fixed;
-  top: 0; left: 0;
-  width: 80vw;
-  max-width: 340px;
-  height: 100vh;
-  background: #fff;
-  box-shadow: 2px 0 32px #0005;
-  padding: 2rem 1.1rem 1.1rem 1.1rem;
-  z-index: 1200;
-  transform: translateX(-100%);
-  transition: transform 0.3s cubic-bezier(.7,.3,.3,1);
-  gap: 0.7rem;
-  overflow-y: auto;
-}
-.mobile-drawer.open {
-  transform: translateX(0);
-}
-.mobile-drawer a,
-.mobile-drawer button {
-  color: #333;
-  text-decoration: none;
-  padding: 0.75rem 0.7rem;
-  border-radius: 6px;
-  font-weight: 500;
-  background: none;
-  border: none;
-  text-align: left;
-  font-size: 1.08rem;
-  transition: background .18s;
-  cursor: pointer;
-}
-.mobile-drawer a:hover,
-.mobile-drawer button:hover {
-  background: #2979ff;
-  color: #fff;
-}
-.mobile-drawer hr {
-  margin: 1rem 0;
-  border: none;
-  border-top: 1px solid #eee;
-}
-.close-drawer {
-  align-self: flex-end;
-  margin-bottom: 1.2rem;
-  color: #c62828;
-  font-size: 1.3rem;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-/* Drawer backdrop */
-.drawer-backdrop {
-  display: none;
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw; height: 100vh;
-  background: rgba(30,30,30,0.28);
-  z-index: 1100;
-  transition: opacity 0.2s;
-}
-.drawer-backdrop.open {
-  display: block;
-  opacity: 1;
-}
-
-/* Responsive */
-@media (max-width: 950px) {
-  .navbar__links {
-    display: none;
-  }
-  .hamburger {
-    display: block;
-  }
-}
-
-/* Hide mobile drawer on desktop */
-@media (min-width: 951px) {
-  .mobile-drawer, .drawer-backdrop { display: none !important; }
-}
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 2000;
-  left: 0; top: 0;
-  width: 100vw; height: 100vh;
-  background: rgba(0,0,0,0.38);
-}
-.modal-content {
-  background: #fff;
-  margin: 7% auto;
-  border-radius: 14px;
-  width: 94%;
-  max-width: 375px;
-  padding: 2.2rem 1.7rem 1.2rem 1.7rem;
-  position: relative;
-  box-shadow: 0 8px 44px #2979ff22;
-  color: #2d3a4a;
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-.close {
-  position: absolute;
-  right: 1.1rem;
-  top: 1.1rem;
-  font-size: 2rem;
-  color: #888;
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: color .18s;
-}
-.close:hover { color: #d32f2f; }
-/* Form elements */
-.modal-content input {
-  width: 100%;
-  margin: 0.5rem 0;
-  border-radius: 8px;
-  border: 1.5px solid #bbb;
-  padding: 0.8rem;
-  font-size: 1.07rem;
-  background: #fff;
-  color: #222;
-  transition: border .17s;
-}
-.modal-content input:focus {
-  outline: none;
-  border: 2px solid #2979ff;
-}
-.modal-content button[type="submit"], .google-btn {
-  width: 100%;
-  margin: 0.7rem 0 0.2rem 0;
-  background: #2979ff;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 0.8rem 0;
-  font-size: 1.08rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background .18s;
-}
-.modal-content button[type="submit"]:hover, .google-btn:hover {
-  background: #1565c0;
-}
-.google-btn {
-  background: #4285F4;
-  margin-bottom: 0.5rem;
-}
-.google-btn:hover {
-  background: #357ae8;
-}
-.error-message {
-  color: #d32f2f;
-  font-size: 0.98rem;
-  text-align: left;
-  margin-top: 0.4rem;
-}
-.reset-password {
-  color: #2979ff;
-  text-decoration: underline;
-  cursor: pointer;
-  font-size: 0.98rem;
-  transition: color .18s;
-}
-.reset-password:hover { color: #d32f2f; }
-</style>
-
-<script>
-/* Account dropdown */
-document.getElementById('profileIcon').addEventListener('click', function(e) {
-  e.stopPropagation();
-  const menu = document.getElementById('accountMenu');
-  menu.classList.toggle('open');
-});
-document.addEventListener('click', function(e) {
-  document.getElementById('accountMenu').classList.remove('open');
-});
-
-/* Mobile drawer open/close */
-const hamburger = document.getElementById('hamburgerBtn');
-const drawer = document.getElementById('mobileDrawer');
-const backdrop = document.getElementById('drawerBackdrop');
-const closeBtn = document.getElementById('closeDrawerBtn');
-function openDrawer() {
-  drawer.classList.add('open');
-  backdrop.classList.add('open');
-  document.body.style.overflow = 'hidden';
-}
-function closeDrawer() {
-  drawer.classList.remove('open');
-  backdrop.classList.remove('open');
-  document.body.style.overflow = '';
-}
-hamburger.addEventListener('click', function(e) {
-  e.stopPropagation(); openDrawer();
-});
-closeBtn.addEventListener('click', closeDrawer);
-backdrop.addEventListener('click', closeDrawer);
-
-/* Highlight active nav link */
-const setActiveLink = (selector) => {
-  const links = document.querySelectorAll(selector);
-  const path = window.location.pathname.split('/').pop();
-  links.forEach(link => {
-    if (link.getAttribute('href') === path) {
-      link.classList.add('active');
-    }
-  });
-};
-setActiveLink('.navbar__links a');
-setActiveLink('.mobile-drawer a');
-
-/* Modal logic */
-function clearFormMessages() {
-  document.getElementById('loginError').style.display = 'none';
-  document.getElementById('signupError').style.display = 'none';
-  document.getElementById('resetError').style.display = 'none';
-}
-function openModal(mode) {
-  document.getElementById('authModal').style.display = 'block';
-  document.getElementById('loginFormContainer').style.display = (mode==='login') ? '' : 'none';
-  document.getElementById('signupFormContainer').style.display = (mode==='signup') ? '' : 'none';
-  document.getElementById('resetFormContainer').style.display = 'none';
-  clearFormMessages();
-}
-function closeModal() {
-  document.getElementById('authModal').style.display = 'none';
-  clearFormMessages();
-}
-document.getElementById('closeModal').onclick = closeModal;
-window.onclick = function(event) {
-  if (event.target === document.getElementById('authModal')) closeModal();
-};
-document.addEventListener('keydown', function(event) {
-  if (event.key === "Escape") closeModal();
-});
-
-/* Switch between forms */
-document.getElementById('showSignup').onclick = function(e) {
-  e.preventDefault(); openModal('signup');
-};
-document.getElementById('showLogin').onclick = function(e) {
-  e.preventDefault(); openModal('login');
-};
-document.getElementById('showLoginFromReset').onclick = function(e) {
-  e.preventDefault(); openModal('login');
-};
-document.getElementById('showReset').onclick = function(e) {
-  e.preventDefault();
-  document.getElementById('loginFormContainer').style.display = 'none';
-  document.getElementById('signupFormContainer').style.display = 'none';
-  document.getElementById('resetFormContainer').style.display = '';
-  clearFormMessages();
-};
-
-/* Dummy handlers for forms (replace with your own backend/auth logic) */
-document.getElementById('loginForm').onsubmit = function(e) {
-  e.preventDefault();
-  // Replace with actual login logic
-  closeModal();
-  alert('Logged in (demo)');
-};
-document.getElementById('signupForm').onsubmit = function(e) {
-  e.preventDefault();
-  // Replace with actual signup logic
-  closeModal();
-  alert('Signed up (demo)');
-};
-document.getElementById('resetForm').onsubmit = function(e) {
-  e.preventDefault();
-  // Replace with actual reset logic
-  closeModal();
-  alert('Password reset link sent (demo)');
-};
-document.querySelectorAll('.google-btn').forEach(btn => {
-  btn.onclick = function(e) {
-    e.preventDefault();
-    closeModal();
-    alert('Google sign-in (demo)');
-  };
-});
-
-/* Dummy sign out */
-function signOut() {
-  closeModal();
-  alert('Signed out (demo)');
-}
-</script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-  </header>
-  <section class="card text-center">
-    <h2>Latest Blog Posts</h2>
-    <p>Get updates, tips, and stories about London transport and city life.</p>
-  </section>
-  <section class="blog-preview">
-    <div class="blog-card">
-      <div class="blog-date">2025-05-15</div>
-      <h3>10 Tips for Navigating the Tube Like a Pro</h3>
-      <p>Discover the secrets to getting around London quickly, from Oyster hacks to off-peak travel...</p>
-      <a href="blog-post-1.html" class="button">Read More</a>
-    </div>
-    <div class="blog-card">
-      <div class="blog-date">2025-05-10</div>
-      <h3>Best Apps for London Commuters</h3>
-      <p>We compare the best journey planners, live status apps, and payment solutions for city travel...</p>
-      <a href="blog-post-2.html" class="button">Read More</a>
-    </div>
-    <!-- Add more blog-card entries as needed -->
-  </section>
   <footer>
     <div class="footer-links">
-      <a href="index.html">Home</a> | 
-      <a href="about.html">About</a> | 
+      <a href="about.html">About</a> |
+      <a href="privacy.html">Privacy</a> |
+      <a href="terms.html">Terms</a> |
       <a href="contact.html">Contact</a>
     </div>
-    <small>© 2025 RouteFlow London</small>
+    <div class="social-icons">
+      <a href="https://discord.gg/qVf3nN4Mgq"><i class="fa-brands fa-discord"></i></a>
+      <a href="https://www.tiktok.com/@the_bus_father"><i class="fab fa-tiktok"></i></a>
+      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"><i class="fab fa-instagram"></i></a>
+    </div>
+    <small>Made for London. Built from scratch.</small>
   </footer>
+
   <script src="navbar-loader.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <script src="main.js"></script>
+  <script type="module">
+    import { getStoredBlogPosts } from './data-store.js';
+    import './blog.js';
+
+    const updateStats = () => {
+      const posts = getStoredBlogPosts();
+      const latest = posts[0];
+      const totalElement = document.getElementById('blogTotalPosts');
+      const latestElement = document.getElementById('blogLatestDate');
+      if (totalElement) {
+        totalElement.textContent = posts.length.toString();
+      }
+      if (latestElement) {
+        if (latest?.publishedAt) {
+          const date = new Date(latest.publishedAt);
+          latestElement.textContent = Number.isFinite(date.getTime())
+            ? date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+            : latest.publishedAt;
+        } else {
+          latestElement.textContent = '—';
+        }
+      }
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', updateStats, { once: true });
+    } else {
+      updateStats();
+    }
+
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'routeflow.blogPosts') {
+        updateStats();
+      }
+    });
+  </script>
 </body>
 </html>

--- a/blog.js
+++ b/blog.js
@@ -1,0 +1,194 @@
+import { getStoredBlogPosts } from './data-store.js';
+
+const formatPublishedDate = (value) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  });
+};
+
+const resolvePostUrl = (post) => {
+  const slug = (post?.id && String(post.id)) || '';
+  return slug ? `blog.html#blog-${slug}` : 'blog.html';
+};
+
+const createTagPill = (tag) => {
+  const pill = document.createElement('span');
+  pill.className = 'blog-tag';
+  pill.textContent = tag;
+  return pill;
+};
+
+const renderTags = (tags = []) => {
+  const unique = Array.isArray(tags) ? tags.filter(Boolean) : [];
+  if (!unique.length) return null;
+  const list = document.createElement('div');
+  list.className = 'blog-post__tags';
+  unique.forEach((tag) => {
+    list.appendChild(createTagPill(tag));
+  });
+  return list;
+};
+
+const renderContent = (post, variant) => {
+  const body = document.createElement('div');
+  body.className = 'blog-post__body';
+
+  if (post.summary) {
+    const summary = document.createElement('p');
+    summary.className = 'blog-post__summary';
+    summary.textContent = post.summary;
+    body.appendChild(summary);
+  }
+
+  if (variant === 'full' && post.content) {
+    const paragraphs = String(post.content)
+      .split(/\n{2,}/)
+      .map((block) => block.trim())
+      .filter(Boolean);
+
+    if (paragraphs.length) {
+      const detail = document.createElement('details');
+      detail.className = 'blog-post__details';
+      detail.open = true;
+
+      const summaryToggle = document.createElement('summary');
+      summaryToggle.textContent = 'Full story';
+      detail.appendChild(summaryToggle);
+
+      paragraphs.forEach((text) => {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = text;
+        detail.appendChild(paragraph);
+      });
+
+      body.appendChild(detail);
+    }
+  }
+
+  return body;
+};
+
+const createMetaLine = (post) => {
+  const meta = document.createElement('p');
+  meta.className = 'blog-post__meta';
+
+  const time = document.createElement('time');
+  time.dateTime = post.publishedAt;
+  time.textContent = formatPublishedDate(post.publishedAt);
+  meta.appendChild(time);
+
+  if (post.author) {
+    const author = document.createElement('span');
+    author.textContent = ` • ${post.author}`;
+    meta.appendChild(author);
+  }
+
+  if (post.readTime) {
+    const read = document.createElement('span');
+    read.textContent = ` • ${post.readTime} min read`;
+    meta.appendChild(read);
+  }
+
+  return meta;
+};
+
+const createHeroImage = (post) => {
+  if (!post.heroImage) return null;
+  const figure = document.createElement('figure');
+  figure.className = 'blog-post__media';
+  const image = document.createElement('img');
+  image.src = post.heroImage;
+  image.alt = post.title ? `${post.title} illustration` : 'Blog illustration';
+  figure.appendChild(image);
+  return figure;
+};
+
+const createBlogElement = (post, variant = 'card', index = 0) => {
+  const article = document.createElement('article');
+  article.className = ['blog-post', `blog-post--${variant}`]
+    .concat(post.featured ? 'blog-post--featured' : [])
+    .join(' ');
+  if (post.id) {
+    article.id = `blog-${post.id}`;
+  }
+
+  const titleLevel = variant === 'full' ? 'h2' : 'h3';
+  const title = document.createElement(titleLevel);
+  title.className = 'blog-post__title';
+
+  const link = document.createElement('a');
+  link.href = resolvePostUrl(post);
+  link.textContent = post.title;
+  link.className = 'blog-post__link';
+  title.appendChild(link);
+
+  const header = document.createElement('header');
+  header.className = 'blog-post__header';
+  header.appendChild(title);
+  header.appendChild(createMetaLine(post));
+
+  const tags = renderTags(post.tags);
+  if (tags) {
+    header.appendChild(tags);
+  }
+
+  const heroImage = createHeroImage(post);
+  if (heroImage && variant !== 'compact') {
+    article.appendChild(heroImage);
+  }
+
+  article.appendChild(header);
+  article.appendChild(renderContent(post, variant));
+
+  if (variant !== 'full') {
+    const cta = document.createElement('a');
+    cta.href = resolvePostUrl(post);
+    cta.className = 'blog-post__cta';
+    cta.textContent = 'Read the full update';
+    article.appendChild(cta);
+  }
+
+  article.dataset.index = String(index);
+  return article;
+};
+
+const renderBlogLists = () => {
+  const containers = document.querySelectorAll('[data-blog-list]');
+  if (!containers.length) return;
+
+  const posts = getStoredBlogPosts()
+    .slice()
+    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+
+  containers.forEach((container) => {
+    const limit = Number(container.dataset.blogLimit);
+    const variant = container.dataset.blogVariant || 'card';
+    const emptyMessage = container.dataset.blogEmpty || 'No blog posts available yet.';
+
+    const subset = Number.isFinite(limit) && limit > 0 ? posts.slice(0, limit) : posts;
+
+    if (!subset.length) {
+      const empty = document.createElement('p');
+      empty.className = 'blog-empty';
+      empty.textContent = emptyMessage;
+      container.replaceChildren(empty);
+      return;
+    }
+
+    const elements = subset.map((post, index) => createBlogElement(post, variant, index));
+    container.replaceChildren(...elements);
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', renderBlogLists, { once: true });
+} else {
+  renderBlogLists();
+}

--- a/components/navbar.html
+++ b/components/navbar.html
@@ -15,6 +15,7 @@
         <li><a class="navbar__link" data-nav-link href="dashboard.html">Dashboard</a></li>
         <li><a class="navbar__link" data-nav-link href="tracking.html">Tracking</a></li>
         <li><a class="navbar__link" data-nav-link href="planning.html">Planning</a></li>
+        <li><a class="navbar__link" data-nav-link href="blog.html">Blog</a></li>
         <li><a class="navbar__link" data-nav-link href="routes.html">Routes</a></li>
         <li><a class="navbar__link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
         <li><a class="navbar__link" data-nav-link href="disruptions.html">Disruptions</a></li>
@@ -70,6 +71,7 @@
         <li><a class="navbar__drawer-link" data-nav-link href="dashboard.html">Dashboard</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="tracking.html">Tracking</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="planning.html">Planning</a></li>
+        <li><a class="navbar__drawer-link" data-nav-link href="blog.html">Blog</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="routes.html">Routes</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
         <li><a class="navbar__drawer-link" data-nav-link href="disruptions.html">Disruptions</a></li>

--- a/index.html
+++ b/index.html
@@ -13,99 +13,130 @@
 <body>
   <div id="navbar-container"></div>
 
-  <main>
-    <!-- Hero Section -->
-    <section class="landing-hero">
-      <div class="hero-card">
-        <img src="images/New_Routflow_London_Logo.png" alt="RouteFlow London logo" class="hero-logo" />
-        <h1>Welcome to RouteFlow London</h1>
-        <p class="hero-subtitle">Plan journeys, track buses and explore London's network.</p>
-        <div class="hero-buttons">
-          <a class="explore" href="planning.html">Journey Planner</a>
-          <a class="learn" href="tracking.html">Arrival Times</a>
+  <main class="landing">
+    <section class="landing-hero card">
+      <div class="landing-hero__content">
+        <p class="landing-hero__eyebrow">Your companion to London transport</p>
+        <h1>Plan journeys, track arrivals, and follow the network in one place.</h1>
+        <p class="landing-hero__lead">
+          RouteFlow London blends real-time data with enthusiast insights. Check live arrivals across the city, build detailed
+          journeys, and surface the stories behind every route.
+        </p>
+        <div class="landing-hero__actions">
+          <a class="landing-hero__button landing-hero__button--primary" href="tracking.html">
+            <i class="fa-solid fa-wifi"></i>
+            Live tracking
+          </a>
+          <a class="landing-hero__button" href="planning.html">
+            <i class="fa-solid fa-route"></i>
+            Journey planner
+          </a>
+        </div>
+        <dl class="landing-hero__metrics" aria-label="Platform snapshot">
+          <div>
+            <dt>Stops monitored</dt>
+            <dd>20k+</dd>
+          </div>
+          <div>
+            <dt>Journey combinations</dt>
+            <dd>Millions</dd>
+          </div>
+          <div>
+            <dt>Community insights</dt>
+            <dd>Daily</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="landing-hero__preview">
+        <div class="landing-preview">
+          <h2>Live now</h2>
+          <p>See departures update in real time and save the stops that matter most.</p>
+          <ul class="landing-preview__list">
+            <li>
+              <span class="landing-preview__label">Arrivals</span>
+              <strong>Refreshes every 25s</strong>
+            </li>
+            <li>
+              <span class="landing-preview__label">Notes</span>
+              <strong>Pin rare workings</strong>
+            </li>
+            <li>
+              <span class="landing-preview__label">Favourites</span>
+              <strong>Sync across devices</strong>
+            </li>
+          </ul>
+          <a class="landing-preview__cta" href="tracking.html">Open live arrivals</a>
         </div>
       </div>
     </section>
 
-    <!-- Newsletter Section -->
-    <section class="newsletter">
-      <div class="newsletter-box">
-        <h2>Get updates on new features and sightings</h2>
-        <p>Sign up for our newsletter to get the latest on live tracking, rare sightings, and London bus news.</p>
-        <form id="newsletter-form">
-          <input type="email" id="email" placeholder="Enter your email" required />
-          <button type="submit">Subscribe</button>
-        </form>
-        <div class="response" id="response-message"></div>
+    <section class="landing-panels">
+      <article class="landing-panel">
+        <h2>Real-time arrivals</h2>
+        <p>Search any stop or station to see the next departures, grouped by mode with colour-coded badges.</p>
+      </article>
+      <article class="landing-panel">
+        <h2>Multi-mode journey planning</h2>
+        <p>Design trips across bus, Tube, DLR, tram, river and more—with accessibility filters built in.</p>
+      </article>
+      <article class="landing-panel">
+        <h2>Enthusiast archive</h2>
+        <p>Explore withdrawn routes, fleet notes and community sightings straight from the dashboard.</p>
+      </article>
+    </section>
+
+    <section class="landing-tools card">
+      <header class="landing-tools__header">
+        <p class="landing-tools__eyebrow">Essential tools</p>
+        <h2>Made for commuters and enthusiasts alike</h2>
+        <p class="landing-tools__lead">Jump straight into the sections that help you plan, track and analyse London&#39;s network.</p>
+      </header>
+      <div class="landing-tools__grid">
+        <article class="landing-tool landing-tool--accent">
+          <div class="landing-tool__icon" aria-hidden="true"><i class="fa-solid fa-bus"></i></div>
+          <h3>Live tracking</h3>
+          <p>Powerful stop search, instant refreshes, and a personal notebook for rare workings.</p>
+          <a class="landing-tool__link" href="tracking.html">Check arrivals</a>
+        </article>
+        <article class="landing-tool">
+          <div class="landing-tool__icon" aria-hidden="true"><i class="fa-solid fa-map-location-dot"></i></div>
+          <h3>Journey planner</h3>
+          <p>Compare multi-mode options, apply accessibility filters and pick the itinerary that fits.</p>
+          <a class="landing-tool__link" href="planning.html">Plan a journey</a>
+        </article>
+        <article class="landing-tool">
+          <div class="landing-tool__icon" aria-hidden="true"><i class="fa-solid fa-layer-group"></i></div>
+          <h3>Network insights</h3>
+          <p>Deep dive into routes, fleets and historic withdrawals curated for London transport fans.</p>
+          <a class="landing-tool__link" href="routes.html">Explore the data</a>
+        </article>
       </div>
     </section>
 
-    <!-- Carousel Section -->
-    <section class="imagescara">
-      <div class="carousel-container">
-        <div class="carousel-title">New London Buses</div>
-        <button class="carousel-btn prev" aria-label="Previous slide">&lsaquo;</button>
-        <div class="carousel-slide">
-          <figure>
-            <img src="https://static.wikia.nocookie.net/bus-routes-in-london/images/2/25/80403_on_SL3.webp" alt="Enviro 400EV on Route SL3">
-            <figcaption>Enviro 400EV | Route SL3</figcaption>
-          </figure>
-          <figure>
-            <img src="https://southwarknews.co.uk/wp-content/uploads/2024/07/An-image-of-the-new-ie-Tram-bus-which-will-soon-operate-on-Route-358.-Photo-from-Go-Ahead-Mark-Lyons-scaled.jpg" alt="Irizar ie Tram Bus">
-            <figcaption>Irizar ie Tram Bus</figcaption>
-          </figure>
-          <figure>
-            <img src="https://static.wikia.nocookie.net/bus-routes-in-london/images/4/4d/1716-LV24EXC.jpg/revision/latest?cb=20250201152244" alt="Electroliner Kite">
-            <figcaption>Electroliner Kite</figcaption>
-          </figure>
-          <figure>
-            <img src="https://live.staticflickr.com/65535/53653477828_b2582c362c_h.jpg" alt="Volvo BZL">
-            <figcaption>Volvo BZL</figcaption>
-          </figure>
-          <figure>
-            <img src="https://live.staticflickr.com/65535/53811039010_f2d6378c2d_b.jpg" alt="Volvo BZL DD">
-            <figcaption>Volvo BZL DD</figcaption>
-          </figure>
-          <figure>
-            <img src="https://static.wikia.nocookie.net/bus-routes-in-london/images/f/ff/321_EBD.png/revision/latest?cb=20250202221630" alt="BYD BD11">
-            <figcaption>BYD BD11</figcaption>
-          </figure>
-        </div>
-        <button class="carousel-btn next" aria-label="Next slide">&rsaquo;</button>
-        <div class="carousel-dots"></div>
-      </div>
+    <section class="landing-blog card" id="latest-blog">
+      <header class="landing-blog__header">
+        <p class="landing-blog__eyebrow">From the RouteFlow blog</p>
+        <h2>Latest stories and release notes</h2>
+        <p>Fresh updates drop straight onto the homepage once you publish them in the admin console.</p>
+      </header>
+      <div class="landing-blog__grid" data-blog-list data-blog-limit="3" data-blog-variant="card" data-blog-empty="Check back soon for new stories."></div>
+      <footer class="landing-blog__footer">
+        <a class="landing-blog__cta" href="blog.html">Browse all posts</a>
+        <span class="landing-blog__hint">Managed entirely from the admin console.</span>
+      </footer>
     </section>
 
-    <!-- About Section -->
-    <section class="about">
-      <h2>About RouteFlow London</h2>
-      <p>
-        RouteFlow London is a next-generation platform for exploring London's iconic bus network.
-        Track vehicles live, explore rare workings, dive into historical data, and connect with the enthusiast community.
-        Built from scratch for London's unique transit scene.
-      </p>
-    </section>
-
-    <!-- Blog Section -->
-    <section id="blog">
-      <h2>Latest Blog Posts</h2>
-      <div class="blog-preview">
-        <article class="blog-card">
-          <span class="blog-date">May 2025</span>
-          <h3>Hidden Buses of Zone 6</h3>
-          <p>A journey to London's farthest reaches, hunting for rare bus gems and snap-worthy moments.</p>
-        </article>
-        <article class="blog-card">
-          <span class="blog-date">April 2025</span>
-          <h3>Fleet Tech Upgrades</h3>
-          <p>How TfL's newest buses are greener, smarter, and more connected than ever.</p>
-        </article>
-        <article class="blog-card">
-          <span class="blog-date">March 2025</span>
-          <h3>Meet the Enthusiasts</h3>
-          <p>Spotlight on the passionate community tracking London's bus history in real time.</p>
-        </article>
+    <section class="landing-updates card">
+      <div class="landing-updates__content">
+        <h2>Stay in the loop</h2>
+        <p>Subscribe for feature announcements, enthusiast meet-ups and rare vehicle alerts.</p>
       </div>
+      <form id="newsletter-form" class="landing-updates__form">
+        <label for="email" class="sr-only">Email address</label>
+        <input type="email" id="email" placeholder="Enter your email" required />
+        <button type="submit">Subscribe</button>
+        <p class="landing-updates__response" id="response-message" aria-live="polite"></p>
+      </form>
     </section>
   </main>
 
@@ -124,42 +155,10 @@
     <small>Made for London. Built from scratch.</small>
   </footer>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const slide = document.querySelector('.carousel-slide');
-      const figures = slide.querySelectorAll('figure');
-      const prev = document.querySelector('.carousel-btn.prev');
-      const next = document.querySelector('.carousel-btn.next');
-      const dots = document.querySelector('.carousel-dots');
-      let index = 0;
-
-      figures.forEach((_, i) => {
-        const dot = document.createElement('span');
-        dot.className = 'dot' + (i === 0 ? ' active' : '');
-        dot.addEventListener('click', () => moveTo(i));
-        dots.appendChild(dot);
-      });
-
-      function moveTo(i) {
-        index = (i + figures.length) % figures.length;
-        slide.scrollTo({ left: figures[index].offsetLeft, behavior: 'smooth' });
-        updateDots();
-      }
-
-      function updateDots() {
-        dots.querySelectorAll('.dot').forEach((dot, i) => {
-          dot.classList.toggle('active', i === index);
-        });
-      }
-
-      prev.addEventListener('click', () => moveTo(index - 1));
-      next.addEventListener('click', () => moveTo(index + 1));
-    });
-  </script>
   <script src="navbar-loader.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
   <script src="main.js"></script>
+  <script type="module" src="blog.js"></script>
 </body>
 </html>
-

--- a/planning.css
+++ b/planning.css
@@ -1,0 +1,196 @@
+.planning-shell {
+  max-width: 1180px;
+  margin: 2.5rem auto 4rem;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.planning-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.planning-hero__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.planning-hero__content h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+}
+
+.planning-hero__content p {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.planning-hero__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.2rem;
+  margin: 0;
+}
+
+.planning-hero__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.planning-hero__meta dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.planning-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.8rem;
+}
+
+.planning-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.planning-form__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.planning-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.planning-input input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  font: inherit;
+}
+
+.planning-fieldset {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 14px;
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.planning-fieldset legend {
+  font-weight: 700;
+}
+
+.planning-checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.6rem;
+}
+
+.planning-checkboxes label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.planning-submit {
+  align-self: flex-start;
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.6rem;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(41, 121, 255, 0.22);
+}
+
+.planning-submit:hover,
+.planning-submit:focus-visible {
+  background: var(--accent-blue-dark);
+}
+
+.planning-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.planning-side__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.planning-side__card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.planning-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.planning-results header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.planning-error {
+  color: var(--primary);
+  font-weight: 600;
+  min-height: 1.2rem;
+}
+
+.planning-results__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.journey-option {
+  border-radius: 16px;
+  border: 1px solid rgba(41, 121, 255, 0.16);
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  background: rgba(41, 121, 255, 0.05);
+}
+
+.journey-option h3 {
+  margin: 0;
+}
+
+.journey-option ol {
+  margin: 0;
+  padding-left: 1.4rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+@media (max-width: 960px) {
+  .planning-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/planning.html
+++ b/planning.html
@@ -3,58 +3,120 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Journey Planning | Routeflow London</title>
+  <title>Journey Planning | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="planning.css">
   <script src="theme.js" defer></script>
 </head>
 <body>
   <div id="navbar-container"></div>
-  <section class="page-banner">
-    <h1>Journey Planner</h1>
-    <p>Plan your trip across London using TfL data.</p>
-  </section>
-  <main class="planner">
-    <form id="journey-form" class="planner-form">
-      <div class="form-row">
-        <div class="input-group">
-          <label for="from">From</label>
-          <input type="text" id="from" placeholder="Start location" required>
-        </div>
-        <div class="input-group">
-          <label for="to">To</label>
-          <input type="text" id="to" placeholder="Destination" required>
-        </div>
+
+  <main class="planning-shell">
+    <section class="planning-hero card">
+      <div class="planning-hero__content">
+        <p class="planning-hero__eyebrow">Multi-mode journey planner</p>
+        <h1>Design journeys across London with accessibility built in.</h1>
+        <p>Choose your start and destination points, filter by transport mode and accessibility preferences, then compare the best itineraries produced by TfL&#39;s journey planner.</p>
       </div>
-      <fieldset class="filters">
-        <legend>Modes</legend>
-        <div class="checkbox-group">
-          <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
-          <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
-          <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
-          <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
-          <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
-          <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
+      <dl class="planning-hero__meta">
+        <div>
+          <dt>Covered modes</dt>
+          <dd>Bus, Tube, DLR, tram, river, rail</dd>
         </div>
-      </fieldset>
-      <fieldset class="filters">
-        <legend>Accessibility</legend>
-        <div class="checkbox-group">
-          <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
-          <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
-          <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
-          <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
-          <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
+        <div>
+          <dt>Accessibility options</dt>
+          <dd>Stairs, escalators, lifts, step-free</dd>
         </div>
-      </fieldset>
-      <button type="submit">Search</button>
-    </form>
-    <div id="error" class="error"></div>
-    <div id="results"></div>
+        <div>
+          <dt>Powered by</dt>
+          <dd>TfL Journey Planner API</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="planning-layout">
+      <form id="journey-form" class="planning-form card">
+        <div class="planning-form__row">
+          <div class="planning-input">
+            <label for="from">From</label>
+            <input type="text" id="from" placeholder="Start location" required>
+          </div>
+          <div class="planning-input">
+            <label for="to">To</label>
+            <input type="text" id="to" placeholder="Destination" required>
+          </div>
+        </div>
+
+        <fieldset class="planning-fieldset">
+          <legend>Modes</legend>
+          <div class="planning-checkboxes">
+            <label><input type="checkbox" name="mode" value="bus" checked> Bus</label>
+            <label><input type="checkbox" name="mode" value="tube" checked> Tube</label>
+            <label><input type="checkbox" name="mode" value="dlr" checked> DLR</label>
+            <label><input type="checkbox" name="mode" value="overground" checked> Overground</label>
+            <label><input type="checkbox" name="mode" value="tram" checked> Tram</label>
+            <label><input type="checkbox" name="mode" value="river-bus" checked> River Bus</label>
+          </div>
+        </fieldset>
+
+        <fieldset class="planning-fieldset">
+          <legend>Accessibility</legend>
+          <div class="planning-checkboxes">
+            <label><input type="checkbox" name="accessibility" value="NoSolidStairs"> No solid stairs</label>
+            <label><input type="checkbox" name="accessibility" value="NoEscalators"> No escalators</label>
+            <label><input type="checkbox" name="accessibility" value="NoElevators"> No elevators</label>
+            <label><input type="checkbox" name="accessibility" value="StepFreeToVehicle"> Step-free to vehicle</label>
+            <label><input type="checkbox" name="accessibility" value="StepFreeToPlatform"> Step-free to platform</label>
+          </div>
+        </fieldset>
+
+        <button type="submit" class="planning-submit">Search journeys</button>
+      </form>
+
+      <aside class="planning-side">
+        <article class="planning-side__card card">
+          <h3>Make the most of your results</h3>
+          <ul>
+            <li>Compare interchange counts to find the most direct route.</li>
+            <li>Use accessibility filters to surface stations with lifts or ramps.</li>
+            <li>Switch to the tracking page to monitor live departures once you&#39;re on your way.</li>
+          </ul>
+        </article>
+      </aside>
+    </section>
+
+    <section class="planning-results card">
+      <header>
+        <h2>Journey options</h2>
+        <p>Results refresh instantly after each search.</p>
+      </header>
+      <div id="error" class="planning-error" role="alert"></div>
+      <div id="results" class="planning-results__list" aria-live="polite"></div>
+    </section>
   </main>
-  <script src="planning.js"></script>
+
+  <footer>
+    <div class="footer-links">
+      <a href="about.html">About</a> |
+      <a href="privacy.html">Privacy</a> |
+      <a href="terms.html">Terms</a> |
+      <a href="contact.html">Contact</a>
+    </div>
+    <div class="social-icons">
+      <a href="https://discord.gg/qVf3nN4Mgq"><i class="fa-brands fa-discord"></i></a>
+      <a href="https://www.tiktok.com/@the_bus_father"><i class="fab fa-tiktok"></i></a>
+      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"><i class="fab fa-instagram"></i></a>
+    </div>
+    <small>Made for London. Built from scratch.</small>
+  </footer>
+
   <script src="navbar-loader.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <script src="main.js"></script>
+  <script src="planning.js"></script>
 </body>
 </html>

--- a/profile.css
+++ b/profile.css
@@ -55,6 +55,13 @@
   gap: 1.1rem;
 }
 
+.profile-hero__handle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
 .profile-hero__eyebrow {
   margin: 0;
   font-size: 0.75rem;
@@ -78,7 +85,7 @@
 
 .profile-hero__meta {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 0.85rem 1.25rem;
   margin: 0;
 }

--- a/profile.html
+++ b/profile.html
@@ -21,8 +21,17 @@
       <div class="profile-hero__content">
         <p class="profile-hero__eyebrow" id="profileRole">Guest</p>
         <h1 class="profile-hero__title" id="profileName">Your profile</h1>
+        <p class="profile-hero__handle" id="profileUsername" hidden></p>
         <p class="profile-hero__subtitle" id="profileEmail">Sign in to personalise your RouteFlow London experience.</p>
         <dl class="profile-hero__meta">
+          <div>
+            <dt>Display name</dt>
+            <dd id="profileDisplayName">—</dd>
+          </div>
+          <div>
+            <dt>Username</dt>
+            <dd id="profileHandle">—</dd>
+          </div>
           <div>
             <dt>Member since</dt>
             <dd id="profileMemberSince">—</dd>
@@ -34,6 +43,10 @@
           <div>
             <dt>User ID</dt>
             <dd id="profileUid">—</dd>
+          </div>
+          <div>
+            <dt>Primary email</dt>
+            <dd id="profilePrimaryEmail">—</dd>
           </div>
         </dl>
         <div class="profile-hero__actions">

--- a/style.css
+++ b/style.css
@@ -1446,3 +1446,664 @@ body.dark-mode #authModal .auth-modal__link {
   width: 90%;
   box-sizing: border-box;
 }
+/*-------------------------------
+  Admin blog enhancements
+-------------------------------*/
+.admin-form__group--stacked textarea {
+  width: 100%;
+  resize: vertical;
+  font: inherit;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #fff;
+}
+
+body.dark-mode .admin-form__group--stacked textarea {
+  background: rgba(17, 24, 39, 0.8);
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--foreground-dark);
+}
+
+.admin-form__group--checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.admin-form__group--checkbox label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.admin-form__group--checkbox input[type='checkbox'] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.admin-blog-summary {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+/*-------------------------------
+  Landing page redesign
+-------------------------------*/
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+main.landing {
+  max-width: 1180px;
+  margin: 0 auto 4rem;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.75rem;
+}
+
+main.landing .card {
+  background: var(--card-bg-light);
+  border-radius: 18px;
+  box-shadow: 0 12px 36px rgba(15, 23, 42, 0.12);
+  padding: clamp(1.8rem, 3vw, 3rem);
+}
+
+body.dark-mode main.landing .card {
+  background: var(--card-bg-dark);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.55);
+}
+
+main.landing .card p {
+  margin: 0;
+}
+
+main.landing .card p + p {
+  margin-top: 0.6rem;
+}
+
+.landing-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: clamp(1.5rem, 3vw, 3rem);
+  align-items: stretch;
+  background: linear-gradient(135deg, rgba(41, 121, 255, 0.14), rgba(211, 47, 47, 0.12));
+}
+
+body.dark-mode .landing-hero {
+  background: linear-gradient(135deg, rgba(41, 121, 255, 0.18), rgba(211, 47, 47, 0.22));
+}
+
+.landing-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.landing-hero__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.landing-hero__lead {
+  margin: 0;
+  font-size: 1.05rem;
+  max-width: 60ch;
+  line-height: 1.6;
+}
+
+.landing-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.landing-hero__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(41, 121, 255, 0.3);
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--accent-blue);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.landing-hero__button i {
+  font-size: 1.1rem;
+}
+
+.landing-hero__button--primary {
+  background: var(--accent-blue);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 6px 16px rgba(41, 121, 255, 0.28);
+}
+
+.landing-hero__button:hover,
+.landing-hero__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(41, 121, 255, 0.2);
+}
+
+.landing-hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.landing-hero__metrics div {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: inset 0 0 0 1px rgba(41, 121, 255, 0.1);
+}
+
+body.dark-mode .landing-hero__metrics div {
+  background: rgba(17, 24, 39, 0.85);
+}
+
+.landing-hero__metrics dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.65;
+}
+
+.landing-hero__metrics dd {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.landing-hero__preview {
+  display: flex;
+  align-items: stretch;
+}
+
+.landing-preview {
+  background: var(--background-light);
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+body.dark-mode .landing-preview {
+  background: rgba(17, 24, 39, 0.92);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.6);
+}
+
+.landing-preview__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.landing-preview__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.65;
+}
+
+.landing-preview__cta {
+  align-self: flex-start;
+  padding: 0.6rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid rgba(41, 121, 255, 0.3);
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--accent-blue);
+  transition: background var(--transition), color var(--transition);
+}
+
+.landing-preview__cta:hover,
+.landing-preview__cta:focus-visible {
+  background: var(--accent-blue);
+  color: #fff;
+}
+
+.landing-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+}
+
+.landing-panel {
+  background: var(--card-bg-light);
+  border-radius: 16px;
+  padding: 1.6rem;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+body.dark-mode .landing-panel {
+  background: var(--card-bg-dark);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
+}
+
+.landing-panel h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.landing-tools__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.landing-tools__eyebrow {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.landing-tools__lead {
+  font-size: 1rem;
+  opacity: 0.8;
+}
+
+.landing-tools__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.5rem;
+}
+
+.landing-tool {
+  border-radius: 16px;
+  padding: 1.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.landing-tool--accent {
+  background: linear-gradient(135deg, rgba(41, 121, 255, 0.18), rgba(211, 47, 47, 0.16));
+}
+
+body.dark-mode .landing-tool {
+  background: rgba(17, 24, 39, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.landing-tool__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(41, 121, 255, 0.1);
+  color: var(--accent-blue);
+  font-size: 1.25rem;
+}
+
+.landing-tool__link {
+  margin-top: auto;
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.landing-tool__link:hover,
+.landing-tool__link:focus-visible {
+  text-decoration: underline;
+}
+
+.landing-blog__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1.8rem;
+}
+
+.landing-blog__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.landing-blog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.landing-blog__footer {
+  margin-top: 1.8rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.landing-blog__cta {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  background: var(--accent-blue);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 8px 22px rgba(41, 121, 255, 0.24);
+}
+
+.landing-blog__hint {
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.landing-updates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.4rem;
+  align-items: center;
+}
+
+.landing-updates__content h2 {
+  margin: 0 0 0.4rem 0;
+}
+
+.landing-updates__content p {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.landing-updates__form {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.landing-updates__form input {
+  flex: 1 1 220px;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  font: inherit;
+}
+
+.landing-updates__form button {
+  border-radius: 12px;
+  border: none;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.landing-updates__form button:hover,
+.landing-updates__form button:focus-visible {
+  background: var(--primary-dark);
+}
+
+.landing-updates__response {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.9rem;
+  min-height: 1.2rem;
+}
+
+/*-------------------------------
+  Blog post components
+-------------------------------*/
+.blog-post {
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 18px;
+  padding: 1.6rem;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body.dark-mode .blog-post {
+  background: rgba(17, 24, 39, 0.92);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+}
+
+.blog-post--featured {
+  border: 1px solid rgba(41, 121, 255, 0.4);
+}
+
+.blog-post__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.blog-post__title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.blog-post__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-post__link:hover,
+.blog-post__link:focus-visible {
+  text-decoration: underline;
+}
+
+.blog-post__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.blog-post__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.blog-tag {
+  display: inline-flex;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(41, 121, 255, 0.14);
+  color: var(--accent-blue);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.blog-post__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.blog-post__summary {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.6;
+}
+
+.blog-post__details {
+  background: rgba(41, 121, 255, 0.06);
+  border-radius: 12px;
+  padding: 0.8rem 1rem;
+}
+
+.blog-post__details summary {
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+}
+
+.blog-post__details p {
+  margin: 0.6rem 0 0;
+  line-height: 1.6;
+}
+
+.blog-post__media {
+  margin: 0;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.blog-post__media img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.blog-post__cta {
+  align-self: flex-start;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(41, 121, 255, 0.3);
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.blog-post__cta:hover,
+.blog-post__cta:focus-visible {
+  background: var(--accent-blue);
+  color: #fff;
+}
+
+.blog-empty {
+  margin: 0;
+  opacity: 0.7;
+}
+
+/*-------------------------------
+  Responsive tweaks
+-------------------------------*/
+@media (max-width: 960px) {
+  .landing-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-hero__preview {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .landing-tools__grid,
+  .landing-blog__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-updates__form {
+    flex-direction: column;
+  }
+
+  .landing-updates__form button,
+  .landing-updates__form input {
+    width: 100%;
+  }
+}
+/*-------------------------------
+  Blog page layout
+-------------------------------*/
+.blog-shell {
+  max-width: 960px;
+  margin: 2.5rem auto 4rem;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.blog-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.blog-hero__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.blog-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.blog-hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.blog-hero__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.blog-hero__label {
+  font-size: 0.8rem;
+  opacity: 0.7;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.blog-list__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.6rem;
+}
+
+.blog-list__grid {
+  display: grid;
+  gap: 1.8rem;
+}
+
+@media (max-width: 640px) {
+  .blog-hero__meta {
+    flex-direction: column;
+  }
+}

--- a/tracking.css
+++ b/tracking.css
@@ -1,0 +1,336 @@
+:root {
+  --bus: #d01c1f;
+  --tube: #003688;
+  --dlr: #00afad;
+  --overground: #ff6d00;
+  --elizabeth-line: #6633cc;
+  --tram: #00a650;
+  --river-bus: #0aa7b8;
+  --national-rail: #0b3b8c;
+}
+
+.tracking-shell {
+  max-width: 1180px;
+  margin: 2.5rem auto 4rem;
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.tracking-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+  gap: clamp(1.4rem, 4vw, 3rem);
+  align-items: stretch;
+}
+
+.tracking-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tracking-hero__eyebrow {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-blue);
+  font-weight: 700;
+}
+
+.tracking-hero__content h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.tracking-hero__content p {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.tracking-hero__highlights {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.tracking-hero__highlights li {
+  background: rgba(41, 121, 255, 0.08);
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.tracking-hero__highlights span {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.tracking-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.8rem;
+}
+
+.tracking-board {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.tracking-board__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.tracking-board__header h2 {
+  margin: 0 0 0.25rem 0;
+}
+
+.tracking-board__header p {
+  margin: 0;
+  opacity: 0.75;
+}
+
+.tracking-board__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.tracking-board__timestamp {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.tracking-chip {
+  border: 1px solid rgba(41, 121, 255, 0.3);
+  border-radius: 999px;
+  background: rgba(41, 121, 255, 0.08);
+  color: var(--accent-blue);
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+  cursor: pointer;
+}
+
+.tracking-chip:hover,
+.tracking-chip:focus-visible {
+  background: var(--accent-blue);
+  color: #fff;
+}
+
+.tracking-search__field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 14px;
+  padding: 0.6rem 0.8rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+body.dark-mode .tracking-search__field {
+  background: rgba(17, 24, 39, 0.85);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.tracking-search__field input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font: inherit;
+  background: transparent;
+}
+
+.tracking-search__field button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.2rem;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.tracking-search__field button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.tracking-search__results {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  background: var(--card-bg-light);
+  border-radius: 14px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.18);
+  display: none;
+  max-height: 420px;
+  overflow-y: auto;
+  z-index: 20;
+}
+
+body.dark-mode .tracking-search__results {
+  background: var(--card-bg-dark);
+  box-shadow: 0 22px 36px rgba(0, 0, 0, 0.6);
+}
+
+.result {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.result:last-child {
+  border-bottom: none;
+}
+
+.result:hover {
+  background: rgba(41, 121, 255, 0.12);
+}
+
+.r-main {
+  flex: 1;
+}
+
+.r-title {
+  font-weight: 700;
+}
+
+.r-sub {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.tracking-board__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.9fr) minmax(0, 1.4fr) minmax(80px, auto);
+  gap: 1rem;
+  align-items: center;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+body.dark-mode .row {
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.5rem 0.8rem;
+  border-radius: 12px;
+  min-width: 110px;
+}
+
+.dest {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dest b {
+  font-size: 1rem;
+}
+
+.dest small {
+  font-size: 0.82rem;
+  opacity: 0.75;
+}
+
+.eta {
+  justify-self: end;
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.empty {
+  padding: 1rem;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.tracking-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.tracking-side__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tracking-side__card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.tracking-side__link {
+  align-self: flex-start;
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+
+.tracking-side__link:hover,
+.tracking-side__link:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 960px) {
+  .tracking-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .tracking-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .row {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .eta {
+    justify-self: start;
+  }
+
+  .tracking-board__actions {
+    justify-content: flex-start;
+  }
+}

--- a/tracking.html
+++ b/tracking.html
@@ -2,180 +2,107 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tracking | RouteFlow London</title>
   <link rel="icon" href="images/New_Routflow_London_Logo.png" type="image/png">
   <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;600&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="tracking.css">
   <script src="theme.js" defer></script>
-<body>
-
-<!-- Font Awesome -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-
-<!-- Google Fonts -->
-<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Montserrat:wght@600&display=swap" rel="stylesheet">
-
-<div id="navbar-container"></div>
-
-  <main>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>RouteFlow London – Live Arrivals</title>
-<style>
-  :root{
-    --bg:#f7f8fb;
-    --card:#ffffff;
-    --ink:#1a1d21;
-    --muted:#6b7280;
-    --ring:#e5e7eb;
-    --accent:#c8102e;
-    --shadow:0 8px 24px rgba(16,24,40,.06);
-
-    /* Mode colours */
-    --bus:#d01c1f;
-    --tube:#003688;
-    --dlr:#00afad;
-    --overground:#ff6d00;
-    --elizabeth:#6633cc;
-    --tram:#00a650;
-    --river:#0aa7b8;
-    --national:#0b3b8c;
-  }
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{
-    margin:0;
-    background:var(--bg);
-    color:black(--ink);
-    font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
-    display:flex; flex-direction:column; align-items:center;
-  }
-  header{
-    width:100%;
-    padding:24px 16px;
-    background:#fff;
-    border-bottom:1px solid var(--ring);
-    position:sticky; top:0; z-index:10;
-  }
-  .brand{max-width:1100px; margin:0 auto; display:flex; align-items:center; gap:12px;}
-  .brand h1{font-size:20px; font-weight:700; letter-spacing:.2px; margin:0; color:var(--accent)}
-  .brand small{color:var(--muted)}
-  /* Search */
-  .search-wrap{width:100%; max-width:900px; margin:18px auto 8px; padding:0 16px;}
-  .search{
-    position:relative; margin:auto; width:100%;
-    background:var(--card); border:1px solid var(--ring); border-radius:14px; box-shadow:var(--shadow);
-    display:flex; align-items:center; gap:10px; padding:10px 12px;
-  }
-  .search input{
-    flex:1; border:0; outline:0; font-size:16px; padding:10px 12px; background:transparent;
-  }
-  .search button{
-    border:0; background:var(--accent); color:#fff; font-weight:600; padding:10px 14px;
-    border-radius:10px; cursor:pointer;
-  }
-  .search button:disabled{opacity:.5; cursor:not-allowed}
-
-  /* Results dropdown */
-  .results{
-    position:absolute; left:0; right:0; top:calc(100% + 8px);
-    background:var(--card); border:1px solid var(--ring); border-radius:12px; box-shadow:var(--shadow);
-    overflow:auto; max-height:420px; display:none;
-  }
-.result {
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--ring);
-  cursor: pointer;
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  color: red; /* <-- change this to your desired color */
-}
-
-.result:last-child {
-  border-bottom: 0; /* just removes the last border, keeps color from above */
-}
-  .result:hover{background:#f3f4f6}
-  .r-main{flex:1}
-  .r-title{font-weight:700}
-  .r-sub{font-size:12px; color:var(--muted); margin-top:2px}
-  .chip{font-size:12px; background:#eef2f7; border:1px solid var(--ring); padding:2px 6px; border-radius:999px}
-
-  /* Layout */
-  .container{width:100%; max-width:1100px; padding:12px 16px; margin-top:8px; display:grid; grid-template-columns:1fr; gap:16px;}
-  @media (min-width:900px){ .container{grid-template-columns: 1fr;} }
-
-  /* Arrivals board */
-  .board{background:var(--card); border:1px solid var(--ring); border-radius:14px; box-shadow:var(--shadow); overflow:hidden;}
-  .board-head{display:flex; justify-content:space-between; align-items:center; padding:14px 16px; background:#fbfbfc; border-bottom:1px solid var(--ring);}
-  .board-title{font-weight:800}
-  .meta{font-size:12px; color:var(--muted)}
-  .actions{display:flex; align-items:center; gap:8px}
-  .action-btn{background:var(--accent); color:#fff; border:0; border-radius:6px; padding:6px 8px; font-size:12px; cursor:pointer}
-  .rows{display:flex; flex-direction:column}
-  .row{
-    display:grid; grid-template-columns: 110px 1fr 110px; gap:12px;
-    padding:12px 16px; border-bottom:1px solid var(--ring); align-items:center;
-  }
-  .row:last-child{border-bottom:0}
-  .badge{
-    justify-self:start; color:#fff; font-weight:800; letter-spacing:.2px;
-    padding:8px 10px; border-radius:10px; display:inline-flex; align-items:center; gap:8px; min-width:90px; justify-content:center;
-    text-transform:uppercase;
-  }
-  .mode-bus{background:Red(--bus)}
-  .mode-tube{background:Blue(--tube)}
-  .mode-dlr{background:lightblue(--dlr)}
-  .mode-overground{background:orange(--overground)}
-  .mode-elizabeth-line{background:purple(--elizabeth)}
-  .mode-tram{background:green(--tram)}
-  .mode-river-bus{background:darkgreen(--river)}
-  .mode-national-rail{background:black(--national)}
-  .dest{display:flex; flex-direction:column}
-  .dest b{font-weight:700}
-  .dest small{color:var(--muted)}
-  .eta{justify-self:end; font-weight:800}
-  .empty{padding:18px; color:var(--muted)}
-</style>
 </head>
 <body>
-  <header>
-    <div class="brand">
-      <h1>RouteFlow London</h1>
-      <small>Live arrivals for buses, tubes, trams & boats</small>
-    </div>
-    <div class="search-wrap">
-      <div class="search" id="searchBox">
-        <input id="q" type="text" placeholder="Search a station name (e.g. Liverpool Street Station) or paste a Stop ID…" autocomplete="off" />
-        <button id="goBtn" disabled>Search</button>
-        <div class="results" id="results"></div>
-      </div>
-    </div>
-  </header>
+  <div id="navbar-container"></div>
 
-  <main class="container">
-    <section class="board" id="board" aria-live="polite">
-      <div class="board-head">
-        <div>
-          <div class="board-title" id="boardTitle">No stop selected</div>
-          <div class="meta" id="boardMeta">Type a station name and choose a stop from the list.</div>
-        </div>
-        <div class="actions">
-          <button class="action-btn" id="favBtn">☆ Favourite</button>
-          <button class="action-btn" id="noteBtn">📝 Add note</button>
-          <div class="meta" id="updated"></div>
-        </div>
+  <main class="tracking-shell">
+    <section class="tracking-hero card">
+      <div class="tracking-hero__content">
+        <p class="tracking-hero__eyebrow">Live arrival board</p>
+        <h1>Track buses, tubes, trams and river services in real time.</h1>
+        <p>Search for any stop or station across the TfL network to see departures update automatically. Save favourites, jot down notes and keep your personal watch list close at hand.</p>
       </div>
-      <div class="rows" id="rows">
-        <div class="empty">Nothing to show yet.</div>
-      </div>
+      <ul class="tracking-hero__highlights">
+        <li>
+          <span>Live refresh</span>
+          <strong>Every 25 seconds</strong>
+        </li>
+        <li>
+          <span>Modes covered</span>
+          <strong>Bus, Tube, DLR, tram, river, rail</strong>
+        </li>
+        <li>
+          <span>Productivity</span>
+          <strong>Notes &amp; favourites built-in</strong>
+        </li>
+      </ul>
+    </section>
+
+    <section class="tracking-layout">
+      <section class="tracking-board card" aria-live="polite">
+        <header class="tracking-board__header">
+          <div>
+            <h2 id="boardTitle">No stop selected</h2>
+            <p id="boardMeta">Type a station or stop name to get started.</p>
+          </div>
+          <div class="tracking-board__actions">
+            <button class="tracking-chip" id="favBtn" type="button">☆ Favourite</button>
+            <button class="tracking-chip" id="noteBtn" type="button">📝 Add note</button>
+            <span class="tracking-board__timestamp" id="updated"></span>
+          </div>
+        </header>
+
+        <div class="tracking-search">
+          <label class="sr-only" for="q">Search for a stop or station</label>
+          <div class="tracking-search__field" id="searchBox">
+            <input id="q" type="text" placeholder="Search a station name or paste a Stop ID…" autocomplete="off" />
+            <button id="goBtn" type="button" disabled>Search</button>
+            <div class="tracking-search__results" id="results"></div>
+          </div>
+        </div>
+
+        <div class="tracking-board__rows" id="rows">
+          <div class="empty">Nothing to show yet.</div>
+        </div>
+      </section>
+
+      <aside class="tracking-side">
+        <article class="tracking-side__card card">
+          <h3>Tips for faster searches</h3>
+          <ul>
+            <li>Paste a StopPoint ID (e.g. 490008660N) to jump straight to arrivals.</li>
+            <li>Use the favourites button to pin key stops to your profile dashboard.</li>
+            <li>Add notes for rare allocations, disruptions or personal reminders.</li>
+          </ul>
+        </article>
+        <article class="tracking-side__card card">
+          <h3>Need planning tools?</h3>
+          <p>Switch to the journey planner to compare multi-mode routes with accessibility filters.</p>
+          <a class="tracking-side__link" href="planning.html">Open journey planner</a>
+        </article>
+      </aside>
     </section>
   </main>
 
-<script>
+  <footer>
+    <div class="footer-links">
+      <a href="about.html">About</a> |
+      <a href="privacy.html">Privacy</a> |
+      <a href="terms.html">Terms</a> |
+      <a href="contact.html">Contact</a>
+    </div>
+    <div class="social-icons">
+      <a href="https://discord.gg/qVf3nN4Mgq"><i class="fa-brands fa-discord"></i></a>
+      <a href="https://www.tiktok.com/@the_bus_father"><i class="fab fa-tiktok"></i></a>
+      <a href="https://www.instagram.com/thebusfatherofficial/profilecard/?igsh=NXcybzV3cTA2azBo"><i class="fab fa-instagram"></i></a>
+    </div>
+    <small>Made for London. Built from scratch.</small>
+  </footer>
+
+  <script src="navbar-loader.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+  <script src="main.js"></script>
+  <script>
 const APP_KEY = "f17d0725d1654338ab02a361fe41abad";
 const MODES = "bus,tube,overground,dlr,tram,river-bus,national-rail,elizabeth-line";
 const q = document.getElementById('q');
@@ -216,7 +143,6 @@ function formatDistance(m){
   return distanceUnit === "imperial" ? `${(m/1609.344).toFixed(2)} mi` : `${Math.round(m)} m`;
 }
 function modeClass(mode){
-  // Map TfL mode to CSS class
   return `mode-${mode}`;
 }
 function modeIcon(mode){
@@ -242,14 +168,12 @@ async function fetchJSON(url){
 async function search(query){
   if(!query) { results.style.display="none"; return; }
 
-  // If user pasted a StopPoint ID, bypass search
   if(/^\d{8,}[A-Z]?$/i.test(query.trim())){
     results.style.display="none";
     selectStop(query.trim(), "Selected stop");
     return;
   }
 
-  // Use TfL StopPoint Search (path param gives better coverage)
   const searchUrl = `https://api.tfl.gov.uk/StopPoint/Search/${encodeURIComponent(query)}?modes=${encodeURIComponent(MODES)}&maxResults=20&app_key=${APP_KEY}`;
 
   let searchData;
@@ -269,11 +193,9 @@ async function search(query){
     return;
   }
 
-  // For each match, fetch StopPoint details to get stopLetter (platform) and towards and children
   const detailPromises = matches.map(m => fetchJSON(`https://api.tfl.gov.uk/StopPoint/${m.id}?app_key=${APP_KEY}`).catch(()=>null));
   const details = await Promise.all(detailPromises);
 
-  // Expand children so bus stop variants (letters) show individually
   const entries = [];
   details.forEach(sp => {
     if(!sp) return;
@@ -286,7 +208,6 @@ async function search(query){
     }
   });
 
-  // Build results list
   results.innerHTML = entries.map(sp=>{
     const stopName = sp.commonName || sp.name || "";
     const stopLetter = sp.stopLetter || (sp.additionalProperties||[]).find(p=>p.key==="StopLetter")?.value || "";
@@ -328,7 +249,6 @@ async function loadArrivals(stopId, stopName){
   try{
     let data = await fetchJSON(`https://api.tfl.gov.uk/StopPoint/${stopId}/Arrivals?app_key=${APP_KEY}`);
 
-    // If nothing came back, try fetching children and aggregate
     if(!Array.isArray(data) || data.length===0){
       const info = await fetchJSON(`https://api.tfl.gov.uk/StopPoint/${stopId}?app_key=${APP_KEY}`).catch(()=>null);
       if(info && Array.isArray(info.children) && info.children.length){
@@ -345,7 +265,6 @@ async function loadArrivals(stopId, stopName){
       return;
     }
 
-    // Sort by soonest
     data.sort((a,b)=> a.timeToStation - b.timeToStation);
 
     rows.innerHTML = data.map(a=>{
@@ -399,56 +318,66 @@ function selectStop(id, name){
   startRefreshTimer();
 }
 
-/* ---------- wire up ---------- */
-const runSearch = debounce(()=> search(q.value.trim()), 250);
+q.addEventListener('input', debounce((event)=>{
+  const value = event.target.value.trim();
+  goBtn.disabled = !value;
+  search(value);
+}, 250));
 
-q.addEventListener('input', ()=>{
-  goBtn.disabled = q.value.trim().length < 2;
-  runSearch();
-});
-q.addEventListener('focus', ()=>{
-  if(results.innerHTML.trim()) results.style.display="block";
-});
-document.addEventListener('click', (e)=>{
-  if(!document.getElementById('searchBox').contains(e.target)){
-    results.style.display="none";
+q.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    const value = q.value.trim();
+    if (value) {
+      search(value);
+    }
   }
 });
-q.addEventListener('keydown', (e)=>{
-  if(e.key === 'Enter'){
-    e.preventDefault();
-    // If results are visible, do nothing (user can click). If not, force a search.
-    if(results.style.display!=="block") runSearch();
+
+goBtn.addEventListener('click', ()=>{
+  const value = q.value.trim();
+  if(!value) return;
+  search(value);
+});
+
+document.addEventListener('click', (event)=>{
+  if(!event.target.closest('#searchBox')){
+    results.style.display = "none";
   }
 });
-goBtn.addEventListener('click', ()=> runSearch());
 
-</script>
-<script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
-<script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
-<script src="main.js"></script>
-<script type="module">
-import { addFavourite } from './favourites.js';
-import { addNote } from './notes.js';
-
-const favBtn = document.getElementById('favBtn');
-const noteBtn = document.getElementById('noteBtn');
-
-favBtn.addEventListener('click', () => {
-  const user = firebase.auth().currentUser;
-  if (!user || !currentStop) { alert('Select a stop and sign in first'); return; }
-  addFavourite(user.uid, currentStop);
-  favBtn.textContent = '★ Favourited';
+window.addEventListener('beforeunload', () => {
+  if(refreshTimer) clearInterval(refreshTimer);
 });
+  </script>
+  <script type="module">
+    import { addFavourite } from './favourites.js';
+    import { addNote } from './notes.js';
 
-noteBtn.addEventListener('click', () => {
-  const user = firebase.auth().currentUser;
-  if (!user || !currentStop) { alert('Select a stop and sign in first'); return; }
-  const text = prompt('Enter a note for this stop:');
-  if (text) addNote(user.uid, { id: currentStop.id, name: currentStop.name, text });
-});
-</script>
-<script src="navbar-loader.js"></script>
-<link rel="stylesheet" href="navbar.css" />
+    const favBtn = document.getElementById('favBtn');
+    const noteBtn = document.getElementById('noteBtn');
+
+    favBtn?.addEventListener('click', () => {
+      const user = firebase.auth()?.currentUser;
+      if (!user || !currentStop) {
+        alert('Select a stop and sign in first.');
+        return;
+      }
+      addFavourite(user.uid, currentStop);
+      favBtn.textContent = '★ Favourited';
+    });
+
+    noteBtn?.addEventListener('click', () => {
+      const user = firebase.auth()?.currentUser;
+      if (!user || !currentStop) {
+        alert('Select a stop and sign in first.');
+        return;
+      }
+      const text = prompt('Enter a note for this stop:');
+      if (text) {
+        addNote(user.uid, { id: currentStop.id, name: currentStop.name, text });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the home page with new hero, tools, newsletter, and dynamic blog previews backed by the new blog renderer
- add a blog management panel in the admin console with local storage persistence and surface blog posts on the dedicated blog page
- refresh tracking and journey planning layouts, add standalone stylesheets, and expand profile details to show usernames and primary emails
- expose the blog in the navigation bar and create supporting styling updates for the new layouts

## Testing
- no automated tests; static front-end changes

------
https://chatgpt.com/codex/tasks/task_e_68ca5561c7648322822cf4ecf7146bb6