### PR TITLE
Revamp mobile styling and neutralise search badges

### DIFF
--- a/navbar.css
+++ b/navbar.css
@@ -899,3 +899,95 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
     display: inline-flex;
   }
 }
+
+@media (max-width: 640px) {
+  body:not(.dark-mode) .navbar {
+    --navbar-bg: rgba(2, 6, 23, 0.72);
+    --navbar-text: #f8fafc;
+    --navbar-muted: rgba(226, 232, 255, 0.82);
+    --navbar-accent: #38bdf8;
+    --navbar-accent-dark: #2563eb;
+    --navbar-border: rgba(148, 163, 184, 0.28);
+    --navbar-shadow: 0 32px 70px rgba(2, 6, 23, 0.55);
+    --navbar-drawer-bg: rgba(2, 6, 23, 0.92);
+    --navbar-drawer-border: rgba(148, 163, 184, 0.34);
+  }
+
+  .navbar__inner {
+    width: 100%;
+    padding-inline: clamp(1rem, 6vw, 1.4rem);
+  }
+
+  .navbar__brand {
+    gap: 0.6rem;
+  }
+
+  .navbar__brand-tagline {
+    letter-spacing: 0.16em;
+  }
+
+  .navbar__actions {
+    gap: 0.6rem;
+  }
+
+  .navbar__toggle {
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.32);
+    padding: 0.55rem;
+    background: rgba(15, 23, 42, 0.45);
+    color: inherit;
+  }
+
+  .navbar__toggle-bar {
+    width: 20px;
+    height: 2px;
+    background: currentColor;
+  }
+
+  body:not(.dark-mode) .navbar__btn--ghost {
+    background: rgba(148, 163, 184, 0.16);
+    border-color: rgba(148, 163, 184, 0.3);
+    color: #f8fafc;
+  }
+
+  body:not(.dark-mode) .navbar__btn--primary {
+    background: linear-gradient(92deg, #38bdf8 0%, #6366f1 100%);
+    box-shadow: 0 22px 44px rgba(99, 102, 241, 0.32);
+  }
+
+  body:not(.dark-mode) .navbar__drawer {
+    background: rgba(2, 6, 23, 0.92);
+    border-color: rgba(148, 163, 184, 0.34);
+  }
+
+  body:not(.dark-mode) .navbar__drawer-section-title {
+    color: rgba(226, 232, 255, 0.82);
+  }
+
+  body:not(.dark-mode) .navbar__drawer-link,
+  body:not(.dark-mode) .navbar__drawer-action,
+  body:not(.dark-mode) .navbar__drawer-button {
+    color: #f8fafc;
+  }
+
+  body:not(.dark-mode) .navbar__drawer-link:hover,
+  body:not(.dark-mode) .navbar__drawer-link:focus-visible {
+    background: rgba(56, 189, 248, 0.18);
+    color: #38bdf8;
+  }
+
+  body:not(.dark-mode) .navbar__drawer-button--ghost {
+    background: rgba(148, 163, 184, 0.18);
+    border-color: rgba(148, 163, 184, 0.32);
+  }
+
+  body:not(.dark-mode) .navbar__drawer-button--primary {
+    background: linear-gradient(92deg, #38bdf8 0%, #6366f1 100%);
+    box-shadow: 0 22px 44px rgba(99, 102, 241, 0.32);
+  }
+
+  body:not(.dark-mode) .navbar__drawer-profile-manage {
+    background: rgba(148, 163, 184, 0.18);
+    color: #f8fafc;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -2694,3 +2694,239 @@ body.dark-mode .admin-stat__label {
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 640px) {
+  body:not(.dark-mode) {
+    background: radial-gradient(circle at 15% -10%, rgba(56, 189, 248, 0.25) 0%, transparent 58%),
+                radial-gradient(circle at 110% 20%, rgba(99, 102, 241, 0.25) 0%, transparent 62%),
+                linear-gradient(180deg, #020617 0%, #0f172a 48%, #1e293b 100%);
+    color: #f8fafc;
+  }
+
+  main {
+    width: 100%;
+    padding-inline: clamp(1rem, 6vw, 1.6rem);
+    padding-block: clamp(2.6rem, 9vw, 3.6rem);
+    gap: clamp(2.2rem, 8vw, 3.4rem);
+  }
+
+  .landing {
+    gap: clamp(2.2rem, 9vw, 3.6rem);
+  }
+
+  body:not(.dark-mode) .card,
+  body:not(.dark-mode) .page-card,
+  body:not(.dark-mode) .blog-hero,
+  body:not(.dark-mode) .blog-list,
+  body:not(.dark-mode) .blog-spotlight,
+  body:not(.dark-mode) .landing-hero,
+  body:not(.dark-mode) .landing-gamify,
+  body:not(.dark-mode) .landing-devices__card,
+  body:not(.dark-mode) .landing-devices__mock,
+  body:not(.dark-mode) .landing-tools,
+  body:not(.dark-mode) .landing-blog,
+  body:not(.dark-mode) .landing-updates {
+    background: rgba(2, 6, 23, 0.62);
+    border-color: rgba(148, 163, 184, 0.28);
+    box-shadow: 0 42px 80px rgba(2, 6, 23, 0.55);
+  }
+
+  .landing-hero {
+    align-items: center;
+    text-align: center;
+    padding: clamp(2.4rem, 10vw, 3.2rem) clamp(1.2rem, 7vw, 1.8rem);
+  }
+
+  body:not(.dark-mode) .landing-hero {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(37, 99, 235, 0.42) 52%, rgba(15, 23, 42, 0.85) 100%);
+    border-color: rgba(148, 163, 184, 0.32);
+  }
+
+  .landing-hero__content {
+    align-items: center;
+    gap: clamp(1.1rem, 4vw, 1.6rem);
+  }
+
+  .landing-hero__lead {
+    max-width: 36ch;
+    color: rgba(241, 245, 249, 0.88);
+  }
+
+  .landing-hero__actions {
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: 0.9rem;
+  }
+
+  .landing-hero__button {
+    width: 100%;
+    justify-content: center;
+    padding: 0.95rem 1.3rem;
+    border: none;
+    background: rgba(15, 23, 42, 0.45);
+    color: inherit;
+    box-shadow: 0 26px 50px rgba(2, 6, 23, 0.45);
+  }
+
+  .landing-hero__button--primary {
+    background: linear-gradient(92deg, #38bdf8 0%, #6366f1 100%);
+    box-shadow: 0 32px 64px rgba(99, 102, 241, 0.32);
+  }
+
+  .landing-hero__metrics {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(180px, 1fr);
+    overflow-x: auto;
+    padding: 0.55rem 0.35rem;
+    gap: 0.75rem;
+    scroll-snap-type: x mandatory;
+  }
+
+  .landing-hero__metrics div {
+    scroll-snap-align: start;
+  }
+
+  .landing-hero__metrics::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  body:not(.dark-mode) .landing-hero__metrics div {
+    background: rgba(2, 6, 23, 0.58);
+    border: 1px solid rgba(148, 163, 184, 0.32);
+  }
+
+  body:not(.dark-mode) .landing-hero__metrics dt {
+    color: rgba(148, 163, 184, 0.88);
+  }
+
+  body:not(.dark-mode) .landing-hero__metrics dd {
+    color: #f8fafc;
+  }
+
+  .landing-hero__preview {
+    width: 100%;
+    margin-top: clamp(1.6rem, 6vw, 2.4rem);
+  }
+
+  body:not(.dark-mode) .landing-hero__preview {
+    background: rgba(2, 6, 23, 0.58);
+    border-color: rgba(148, 163, 184, 0.28);
+    box-shadow: 0 30px 60px rgba(2, 6, 23, 0.48);
+  }
+
+  .landing-preview__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
+  }
+
+  body:not(.dark-mode) .landing-preview__header {
+    color: rgba(226, 232, 255, 0.9);
+  }
+
+  .landing-panels {
+    grid-template-columns: 1fr;
+    gap: 1.2rem;
+  }
+
+  .landing-panel {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem 1.3rem;
+    border-radius: 22px;
+  }
+
+  body:not(.dark-mode) .landing-panel {
+    background: rgba(2, 6, 23, 0.58);
+    border-color: rgba(148, 163, 184, 0.28);
+  }
+
+  .landing-panel__icon {
+    flex-shrink: 0;
+    width: 48px;
+    height: 48px;
+    font-size: 1.4rem;
+  }
+
+  .landing-gamify {
+    padding: clamp(1.8rem, 7vw, 2.4rem) clamp(1rem, 6vw, 1.4rem);
+  }
+
+  .landing-gamify__grid {
+    grid-template-columns: 1fr;
+    gap: 1.1rem;
+  }
+
+  .landing-gamify__item {
+    padding: 1.35rem;
+    border-radius: 20px;
+  }
+
+  body:not(.dark-mode) .landing-gamify__item {
+    background: rgba(2, 6, 23, 0.56);
+    border-color: rgba(148, 163, 184, 0.26);
+  }
+
+  .landing-devices {
+    grid-template-columns: 1fr;
+    gap: 1.2rem;
+  }
+
+  .landing-devices__card,
+  .landing-devices__mock {
+    padding: clamp(1.8rem, 7vw, 2.4rem) clamp(1.2rem, 6vw, 1.6rem);
+  }
+
+  .landing-devices__mock {
+    order: -1;
+  }
+
+  body:not(.dark-mode) .landing-devices__mock {
+    background: rgba(2, 6, 23, 0.56);
+    border-color: rgba(148, 163, 184, 0.28);
+  }
+
+  .landing-tools__grid,
+  .landing-blog__grid,
+  .landing-updates {
+    grid-template-columns: 1fr;
+    gap: 1.2rem;
+  }
+
+  .landing-tool,
+  .landing-updates {
+    border-radius: 22px;
+  }
+
+  body:not(.dark-mode) .landing-tool {
+    background: rgba(2, 6, 23, 0.58);
+    border-color: rgba(148, 163, 184, 0.28);
+  }
+
+  body:not(.dark-mode) .landing-tool--accent {
+    background: linear-gradient(140deg, rgba(56, 189, 248, 0.32), rgba(99, 102, 241, 0.28));
+    border-color: rgba(148, 163, 184, 0.32);
+  }
+
+  .landing-blog__footer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .landing-blog__cta {
+    justify-content: center;
+  }
+
+  body:not(.dark-mode) .landing-updates__form button {
+    background: linear-gradient(92deg, #38bdf8 0%, #6366f1 100%);
+    box-shadow: 0 24px 50px rgba(99, 102, 241, 0.3);
+  }
+
+  .site-footer {
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+    background: transparent;
+  }
+}

--- a/tracking.css
+++ b/tracking.css
@@ -1102,22 +1102,25 @@ body.dark-mode .tracking-result__line {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #fff;
-  padding: 0.45rem 0.85rem;
-  border-radius: 999px;
-  background: var(--tracking-result-accent, var(--accent-blue));
-  box-shadow: 0 16px 28px rgba(0, 54, 136, 0.28);
+  color: #000;
+  padding: 0.35rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background: rgba(148, 163, 184, 0.12);
   margin-left: auto;
   align-self: center;
   white-space: nowrap;
+  box-shadow: none;
 }
 
 body.dark-mode .tracking-result__badge {
-  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.55);
+  color: #f8fafc;
+  border-color: rgba(226, 232, 255, 0.35);
+  background: rgba(99, 102, 241, 0.22);
 }
 
 .tracking-result__chevron {

--- a/tracking.js
+++ b/tracking.js
@@ -731,8 +731,9 @@
           badge.setAttribute('aria-label', fullLabel);
           badge.setAttribute('title', fullLabel);
         }
-        badge.style.background = pickModeColour(primaryMode);
-        badge.style.color = '#fff';
+        if (primaryMode) {
+          badge.dataset.mode = primaryMode;
+        }
         item.appendChild(badge);
       }
 


### PR DESCRIPTION
## Summary
- Refresh the mobile layout with a new gradient backdrop, glassy cards, and single-column sections tailored for small screens.
- Align the mobile navigation drawer and toggle styling with the updated palette.
- Restyle tracking suggestions so mode badges drop the coloured bubble in favour of neutral text.

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0338b40288322b85df2bb6c4e5af7