### PR TITLE
Redesign navigation layout and styling

### DIFF
--- a/components/navbar.html
+++ b/components/navbar.html
@@ -10,17 +10,32 @@
     </a>
 
     <div class="navbar__desktop" data-navbar-desktop>
-      <ul class="navbar__list" role="list">
-        <li><a class="navbar__link" data-nav-link href="index.html">Home</a></li>
-        <li><a class="navbar__link" data-nav-link href="dashboard.html">Dashboard</a></li>
-        <li><a class="navbar__link" data-nav-link href="tracking.html">Tracking</a></li>
-        <li><a class="navbar__link" data-nav-link href="planning.html">Planning</a></li>
-        <li><a class="navbar__link" data-nav-link href="info.html">Info Hub</a></li>
-        <li><a class="navbar__link" data-nav-link href="routes.html">Routes</a></li>
-        <li><a class="navbar__link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
-        <li><a class="navbar__link" data-nav-link href="disruptions.html">Disruptions</a></li>
-        <li><a class="navbar__link" data-nav-link href="fleet.html">Fleet</a></li>
-      </ul>
+      <div class="navbar__segments" role="navigation" aria-label="Primary navigation">
+        <div class="navbar__segment" role="group" aria-label="Plan and play">
+          <span class="navbar__segment-label">Plan &amp; play</span>
+          <ul class="navbar__list navbar__segment-list" role="list">
+            <li><a class="navbar__link" data-nav-link href="index.html">Home</a></li>
+            <li><a class="navbar__link" data-nav-link href="dashboard.html">Dashboard</a></li>
+            <li><a class="navbar__link" data-nav-link href="planning.html">Planning</a></li>
+          </ul>
+        </div>
+        <div class="navbar__segment" role="group" aria-label="Live status">
+          <span class="navbar__segment-label">Live status</span>
+          <ul class="navbar__list navbar__segment-list" role="list">
+            <li><a class="navbar__link" data-nav-link href="tracking.html">Tracking</a></li>
+            <li><a class="navbar__link" data-nav-link href="routes.html">Routes</a></li>
+            <li><a class="navbar__link" data-nav-link href="disruptions.html">Disruptions</a></li>
+          </ul>
+        </div>
+        <div class="navbar__segment" role="group" aria-label="Community data">
+          <span class="navbar__segment-label">Community data</span>
+          <ul class="navbar__list navbar__segment-list" role="list">
+            <li><a class="navbar__link" data-nav-link href="info.html">Info Hub</a></li>
+            <li><a class="navbar__link" data-nav-link href="fleet.html">Fleet</a></li>
+            <li><a class="navbar__link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
+          </ul>
+        </div>
+      </div>
     </div>
 
     <div class="navbar__actions">
@@ -107,18 +122,30 @@
       </section>
 
       <nav class="navbar__drawer-nav" aria-label="Mobile navigation">
-        <h2 class="navbar__drawer-section-title">Browse</h2>
-        <ul class="navbar__drawer-list" role="list">
-          <li><a class="navbar__drawer-link" data-nav-link href="index.html">Home</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="dashboard.html">Dashboard</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="tracking.html">Tracking</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="planning.html">Planning</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="info.html">Info Hub</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="routes.html">Routes</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="disruptions.html">Disruptions</a></li>
-          <li><a class="navbar__drawer-link" data-nav-link href="fleet.html">Fleet</a></li>
-        </ul>
+        <div class="navbar__drawer-group" role="group" aria-label="Plan and play">
+          <h2 class="navbar__drawer-section-title">Plan &amp; play</h2>
+          <ul class="navbar__drawer-list" role="list">
+            <li><a class="navbar__drawer-link" data-nav-link href="index.html">Home</a></li>
+            <li><a class="navbar__drawer-link" data-nav-link href="dashboard.html">Dashboard</a></li>
+            <li><a class="navbar__drawer-link" data-nav-link href="planning.html">Planning</a></li>
+          </ul>
+        </div>
+        <div class="navbar__drawer-group" role="group" aria-label="Live status">
+          <h2 class="navbar__drawer-section-title">Live status</h2>
+          <ul class="navbar__drawer-list" role="list">
+            <li><a class="navbar__drawer-link" data-nav-link href="tracking.html">Tracking</a></li>
+            <li><a class="navbar__drawer-link" data-nav-link href="routes.html">Routes</a></li>
+            <li><a class="navbar__drawer-link" data-nav-link href="disruptions.html">Disruptions</a></li>
+          </ul>
+        </div>
+        <div class="navbar__drawer-group" role="group" aria-label="Community data">
+          <h2 class="navbar__drawer-section-title">Community data</h2>
+          <ul class="navbar__drawer-list" role="list">
+            <li><a class="navbar__drawer-link" data-nav-link href="info.html">Info Hub</a></li>
+            <li><a class="navbar__drawer-link" data-nav-link href="fleet.html">Fleet</a></li>
+            <li><a class="navbar__drawer-link" data-nav-link href="withdrawn.html">Withdrawn</a></li>
+          </ul>
+        </div>
       </nav>
 
       <div class="navbar__drawer-divider" role="separator" aria-hidden="true"></div>

--- a/navbar.css
+++ b/navbar.css
@@ -1,12 +1,16 @@
 :root {
-  --navbar-bg: rgba(255, 255, 255, 0.92);
+  --navbar-bg: rgba(248, 250, 255, 0.9);
   --navbar-text: #0f172a;
-  --navbar-muted: rgba(15, 23, 42, 0.58);
+  --navbar-muted: rgba(15, 23, 42, 0.55);
   --navbar-accent: var(--accent-red, #d31233);
   --navbar-accent-dark: var(--accent-red-dark, #ab0f27);
-  --navbar-border: rgba(var(--accent-blue-rgb, 18, 58, 122), 0.14);
-  --navbar-shadow: 0 20px 46px rgba(16, 30, 64, 0.14);
-  --navbar-radius: 22px;
+  --navbar-border: rgba(100, 116, 165, 0.22);
+  --navbar-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+  --navbar-radius: 24px;
+  --navbar-pill-gradient: linear-gradient(135deg, rgba(255, 255, 255, 0.88), rgba(233, 240, 255, 0.82));
+  --navbar-pill-border: rgba(var(--accent-blue-rgb, 18, 58, 122), 0.18);
+  --navbar-pill-shadow: 0 22px 48px rgba(var(--accent-blue-rgb, 18, 58, 122), 0.12);
+  --navbar-segment-surface: rgba(255, 255, 255, 0.6);
   --navbar-drawer-bg: rgba(255, 255, 255, 0.96);
   --navbar-drawer-border: rgba(var(--accent-blue-rgb, 18, 58, 122), 0.18);
 }
@@ -32,8 +36,8 @@
   top: 0;
   inset-inline: 0;
   z-index: 1200;
-  backdrop-filter: blur(18px);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.88));
+  backdrop-filter: blur(22px);
+  background: linear-gradient(128deg, rgba(248, 250, 255, 0.9), rgba(226, 235, 255, 0.84));
   border-bottom: 1px solid var(--navbar-border);
   box-shadow: var(--navbar-shadow);
   color: var(--navbar-text);
@@ -46,9 +50,9 @@
 .navbar__inner {
   width: min(1200px, 100%);
   margin: 0 auto;
-  padding: clamp(0.8rem, 2vw, 1.1rem) clamp(1rem, 4vw, 2rem);
+  padding: clamp(0.9rem, 2.6vw, 1.25rem) clamp(1.2rem, 4vw, 2.4rem);
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
   gap: clamp(1rem, 3vw, 2.6rem);
 }
@@ -89,47 +93,182 @@
   flex: 1 1 auto;
   display: flex;
   justify-content: center;
+  align-items: stretch;
+}
+
+.navbar__segments {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(0.75rem, 2.4vw, 1.25rem);
+  background: var(--navbar-pill-gradient);
+  border-radius: calc(var(--navbar-radius) + 8px);
+  padding: clamp(0.8rem, 2.4vw, 1.2rem);
+  border: 1px solid var(--navbar-pill-border);
+  box-shadow: var(--navbar-pill-shadow);
+  position: relative;
+  isolation: isolate;
+  min-width: 0;
+  backdrop-filter: blur(18px);
+}
+
+.navbar__segment {
+  display: grid;
+  gap: 0.55rem;
+  padding: clamp(0.4rem, 1.8vw, 0.7rem) clamp(0.5rem, 2vw, 0.85rem);
+  border-radius: calc(var(--navbar-radius) - 6px);
+  background: var(--navbar-segment-surface);
+  border: 1px solid rgba(var(--accent-blue-rgb, 18, 58, 122), 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  min-width: 0;
+  overflow: hidden;
+  backdrop-filter: blur(10px);
+}
+
+.navbar__segment-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--navbar-muted);
+  font-weight: 700;
 }
 
 .navbar__list {
-  display: inline-flex;
-  align-items: center;
-  gap: clamp(0.4rem, 2vw, 1rem);
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.navbar__link,
-.navbar__drawer-link {
-  display: inline-flex;
-  align-items: center;
+.navbar__segment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
   gap: 0.35rem;
-  padding: 0.55rem 1rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  font-size: 0.98rem;
-  font-weight: 600;
+  min-width: 0;
+}
+
+.navbar__segment-list li {
+  min-width: 0;
+}
+
+.navbar__link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+  width: 100%;
+  padding: clamp(0.55rem, 2vw, 0.7rem) clamp(0.7rem, 2vw, 0.9rem);
+  border-radius: 14px;
+  border: 1px solid rgba(var(--accent-blue-rgb, 18, 58, 122), 0.12);
+  background: rgba(255, 255, 255, 0.72);
   color: var(--navbar-text);
+  font-size: 0.95rem;
+  font-weight: 600;
   text-decoration: none;
-  transition: color 0.16s ease, background-color 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
+  box-shadow: 0 12px 24px rgba(var(--accent-blue-rgb, 18, 58, 122), 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.navbar__link::after {
+  content: '\2197';
+  font-size: 0.85rem;
+  opacity: 0;
+  transform: translateY(4px);
+  color: var(--navbar-muted);
+  transition: opacity 0.2s ease, transform 0.2s ease, color 0.2s ease;
 }
 
 .navbar__link:hover,
-.navbar__drawer-link:hover {
+.navbar__link:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(var(--accent-blue-rgb, 18, 58, 122), 0.32);
+  box-shadow: 0 20px 44px rgba(var(--accent-blue-rgb, 18, 58, 122), 0.22);
+  color: var(--navbar-text);
+}
+
+.navbar__link:hover::after,
+.navbar__link:focus-visible::after {
+  opacity: 1;
+  transform: translateY(0);
   color: var(--navbar-accent);
-  background: rgba(var(--accent-blue-rgb, 18, 58, 122), 0.08);
-  border-color: rgba(var(--accent-blue-rgb, 18, 58, 122), 0.16);
 }
 
 .navbar__link.is-active,
-.navbar__link[aria-current="page"],
-.navbar__drawer-link.is-active,
-.navbar__drawer-link[aria-current="page"] {
+.navbar__link[aria-current="page"] {
+  color: var(--navbar-text);
+  background: linear-gradient(135deg, rgba(var(--accent-red-rgb, 211, 18, 51), 0.18), rgba(var(--accent-blue-rgb, 18, 58, 122), 0.24));
+  border-color: rgba(var(--accent-red-rgb, 211, 18, 51), 0.38);
+  box-shadow: 0 26px 52px rgba(var(--accent-red-rgb, 211, 18, 51), 0.28);
+}
+
+.navbar__link.is-active::after,
+.navbar__link[aria-current="page"]::after {
+  opacity: 1;
+  transform: translateY(0);
   color: var(--navbar-accent-dark);
-  background: linear-gradient(135deg, rgba(var(--accent-red-rgb, 211, 18, 51), 0.18), rgba(var(--accent-blue-rgb, 18, 58, 122), 0.12));
-  border-color: rgba(var(--accent-red-rgb, 211, 18, 51), 0.28);
-  box-shadow: 0 16px 36px rgba(var(--accent-red-rgb, 211, 18, 51), 0.22);
+}
+
+body.dark-mode .navbar {
+  background: linear-gradient(128deg, rgba(7, 12, 28, 0.96), rgba(16, 23, 42, 0.92));
+  border-bottom-color: rgba(88, 110, 255, 0.28);
+  color: #f4f6ff;
+}
+
+body.dark-mode .navbar__brand-tagline {
+  color: rgba(226, 232, 255, 0.68);
+}
+
+body.dark-mode .navbar__segments {
+  background: linear-gradient(135deg, rgba(18, 28, 56, 0.82), rgba(32, 52, 92, 0.78));
+  border-color: rgba(88, 110, 255, 0.32);
+  box-shadow: 0 26px 56px rgba(5, 9, 22, 0.6);
+  backdrop-filter: blur(18px);
+}
+
+body.dark-mode .navbar__segment {
+  background: rgba(15, 21, 40, 0.7);
+  border-color: rgba(88, 110, 255, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+body.dark-mode .navbar__segment-label {
+  color: rgba(226, 232, 255, 0.62);
+}
+
+body.dark-mode .navbar__link {
+  background: rgba(18, 24, 46, 0.82);
+  border-color: rgba(88, 110, 255, 0.28);
+  color: #f4f6ff;
+  box-shadow: 0 16px 32px rgba(5, 9, 22, 0.6);
+}
+
+body.dark-mode .navbar__link::after {
+  color: rgba(226, 232, 255, 0.6);
+}
+
+body.dark-mode .navbar__link:hover,
+body.dark-mode .navbar__link:focus-visible {
+  background: rgba(48, 66, 128, 0.78);
+  border-color: rgba(125, 146, 255, 0.48);
+  box-shadow: 0 26px 52px rgba(8, 14, 32, 0.65);
+}
+
+body.dark-mode .navbar__link:hover::after,
+body.dark-mode .navbar__link:focus-visible::after {
+  color: #ffb5c2;
+}
+
+body.dark-mode .navbar__link.is-active,
+body.dark-mode .navbar__link[aria-current="page"] {
+  background: linear-gradient(135deg, rgba(var(--accent-red-rgb, 211, 18, 51), 0.32), rgba(94, 122, 255, 0.4));
+  border-color: rgba(249, 148, 164, 0.45);
+  box-shadow: 0 32px 60px rgba(10, 16, 36, 0.7);
+}
+
+body.dark-mode .navbar__link.is-active::after,
+body.dark-mode .navbar__link[aria-current="page"]::after {
+  color: #ffd6da;
 }
 
 .navbar__actions {
@@ -545,6 +684,16 @@ body.dark-mode .navbar__drawer::before {
   gap: 1rem;
 }
 
+.navbar__drawer-group {
+  display: grid;
+  gap: clamp(0.6rem, 3vw, 0.9rem);
+  padding: clamp(0.85rem, 3.6vw, 1.1rem) clamp(0.9rem, 4vw, 1.25rem);
+  border-radius: clamp(18px, 4vw, 22px);
+  background: rgba(var(--accent-blue-rgb, 64, 103, 229), 0.08);
+  border: 1px solid rgba(var(--accent-blue-rgb, 64, 103, 229), 0.16);
+  box-shadow: 0 18px 46px rgba(var(--accent-blue-rgb, 64, 103, 229), 0.16);
+}
+
 .navbar__drawer-section-title {
   font-size: 0.78rem;
   letter-spacing: 0.18em;
@@ -569,12 +718,13 @@ body.dark-mode .navbar__drawer::before {
   gap: 0.6rem;
   padding: 0.95rem 1.1rem;
   border-radius: clamp(16px, 4vw, 18px);
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(var(--accent-blue-rgb, 64, 103, 229), 0.16);
   box-shadow: 0 18px 46px rgba(var(--accent-blue-rgb, 64, 103, 229), 0.16);
   color: var(--navbar-text);
   font-weight: 600;
   text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
 .navbar__drawer-link::after {
@@ -588,7 +738,8 @@ body.dark-mode .navbar__drawer::before {
 
 .navbar__drawer-link:hover,
 .navbar__drawer-link:focus-visible {
-  background: rgba(var(--accent-blue-rgb, 64, 103, 229), 0.18);
+  background: rgba(255, 255, 255, 0.98);
+  border-color: rgba(var(--accent-blue-rgb, 64, 103, 229), 0.3);
   color: var(--navbar-text);
   transform: translateX(6px);
 }
@@ -596,6 +747,20 @@ body.dark-mode .navbar__drawer::before {
 .navbar__drawer-link:hover::after,
 .navbar__drawer-link:focus-visible::after {
   color: var(--navbar-text);
+  transform: translateX(2px);
+}
+
+.navbar__drawer-link.is-active,
+.navbar__drawer-link[aria-current="page"] {
+  background: linear-gradient(135deg, rgba(var(--accent-red-rgb, 211, 18, 51), 0.18), rgba(var(--accent-blue-rgb, 64, 103, 229), 0.26));
+  border-color: rgba(var(--accent-red-rgb, 211, 18, 51), 0.32);
+  color: var(--navbar-text);
+  box-shadow: 0 26px 54px rgba(var(--accent-red-rgb, 211, 18, 51), 0.24);
+}
+
+.navbar__drawer-link.is-active::after,
+.navbar__drawer-link[aria-current="page"]::after {
+  color: var(--navbar-accent);
   transform: translateX(2px);
 }
 
@@ -750,9 +915,16 @@ body.dark-mode .navbar__drawer-profile-email {
   color: rgba(246, 247, 255, 0.72);
 }
 
+body.dark-mode .navbar__drawer-group {
+  background: rgba(18, 24, 46, 0.72);
+  border-color: rgba(88, 110, 255, 0.3);
+  box-shadow: 0 24px 52px rgba(5, 9, 22, 0.65);
+}
+
 body.dark-mode .navbar__drawer-link {
-  background: rgba(16, 23, 42, 0.92);
-  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.45);
+  background: rgba(16, 23, 42, 0.88);
+  border-color: rgba(88, 110, 255, 0.36);
+  box-shadow: 0 24px 52px rgba(0, 0, 0, 0.45);
 }
 
 body.dark-mode .navbar__drawer-link::after {
@@ -762,6 +934,7 @@ body.dark-mode .navbar__drawer-link::after {
 body.dark-mode .navbar__drawer-link:hover,
 body.dark-mode .navbar__drawer-link:focus-visible {
   background: rgba(88, 110, 255, 0.32);
+  border-color: rgba(140, 158, 255, 0.5);
 }
 
 body.dark-mode .navbar__drawer-link:hover::after,
@@ -769,8 +942,24 @@ body.dark-mode .navbar__drawer-link:focus-visible::after {
   color: #f6f7ff;
 }
 
+body.dark-mode .navbar__drawer-link.is-active,
+body.dark-mode .navbar__drawer-link[aria-current="page"] {
+  background: linear-gradient(135deg, rgba(var(--accent-red-rgb, 211, 18, 51), 0.38), rgba(120, 140, 255, 0.45));
+  border-color: rgba(255, 179, 188, 0.55);
+  box-shadow: 0 30px 60px rgba(4, 9, 22, 0.6);
+}
+
+body.dark-mode .navbar__drawer-link.is-active::after,
+body.dark-mode .navbar__drawer-link[aria-current="page"]::after {
+  color: #ffd6da;
+}
+
 body.dark-mode .navbar__drawer-divider {
   background: rgba(255, 255, 255, 0.16);
+}
+
+body.dark-mode .navbar__drawer-section-title {
+  color: rgba(226, 232, 255, 0.62);
 }
 
 body.dark-mode .navbar__drawer-copy {
@@ -852,6 +1041,10 @@ body.dark-mode .navbar__drawer-button--destructive:focus-visible {
 
   .navbar__drawer-link {
     padding: 0.9rem 1rem;
+  }
+
+  .navbar__drawer-group {
+    padding: 0.85rem 1rem;
   }
 
   .navbar__drawer-profile {


### PR DESCRIPTION
## Summary
- regroup the desktop navigation into themed segments and mirror the same structure inside the mobile drawer for easier discovery
- refresh the navbar and drawer styling with glassmorphism-inspired gradients, updated dark mode palettes, and richer active/hover states

## Testing
- Not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d271cc93188322851b172d47fa1c50