### PR TITLE
Refactor police job resource to QB-Core style

### DIFF
--- a/backend/fivem/police_job/client/evidence.lua
+++ b/backend/fivem/police_job/client/evidence.lua
@@ -1,0 +1,51 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local function isPoliceOnDuty()
+    local playerData = QBCore.Functions.GetPlayerData()
+    if not playerData or not playerData.job then return false end
+    return playerData.job.name == Config.JobName and playerData.job.onduty
+end
+
+local function buildEvidenceMetadata(description)
+    local ped = PlayerPedId()
+    local coords = GetEntityCoords(ped)
+    local streetHash, crossingHash = GetStreetNameAtCoord(coords.x, coords.y, coords.z)
+    local streetName = GetStreetNameFromHashKey(streetHash)
+    local crossing = GetStreetNameFromHashKey(crossingHash)
+    local area = streetName
+    if crossing ~= '' then
+        area = ('%s / %s'):format(streetName, crossing)
+    end
+
+    return {
+        location = area,
+        description = description or 'Collected evidence',
+        coords = { x = coords.x, y = coords.y, z = coords.z },
+        time = os.date('%Y-%m-%d %H:%M:%S')
+    }
+end
+
+RegisterNetEvent('police:client:CreateEvidenceBag', function(data)
+    if not isPoliceOnDuty() then
+        QBCore.Functions.Notify('You must be on duty to collect evidence', 'error')
+        return
+    end
+
+    local description = data and data.description or 'Evidence sample'
+    QBCore.Functions.Progressbar('collect-evidence', 'Bagging Evidence...', 5000, false, true, {
+        disableMovement = true,
+        disableCarMovement = true,
+        disableMouse = false,
+        disableCombat = true
+    }, {}, {}, {}, function()
+        local metadata = buildEvidenceMetadata(description)
+        TriggerServerEvent('police:server:CreateEvidenceBag', metadata)
+        QBCore.Functions.Notify('Evidence bag sealed and added to your inventory', 'success')
+    end)
+end)
+
+RegisterNetEvent('police:client:UseBodycam', function()
+    if not isPoliceOnDuty() then return end
+    QBCore.Functions.Notify('Bodycam recording timestamp updated', 'primary')
+    TriggerServerEvent('police:server:UpdateBodycamLog')
+end)

--- a/backend/fivem/police_job/client/garage.lua
+++ b/backend/fivem/police_job/client/garage.lua
@@ -1,0 +1,134 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local PlayerJob = {}
+
+local function isPolice()
+    return PlayerJob.name == Config.JobName
+end
+
+local function getVehiclesForType(vehicleType)
+    local authorized = {}
+    if not isPolice() then return authorized end
+    local grade = PlayerJob.grade and PlayerJob.grade.level or 0
+    local pool = Config.AuthorizedVehicles[vehicleType] or {}
+    for requiredGrade, vehicles in pairs(pool) do
+        if grade >= requiredGrade then
+            for _, info in ipairs(vehicles) do
+                authorized[#authorized + 1] = info
+            end
+        end
+    end
+    table.sort(authorized, function(a, b)
+        return (a.label or a.model) < (b.label or b.model)
+    end)
+    return authorized
+end
+
+RegisterNetEvent('police:client:HandleGarageMenu', function(data)
+    local playerData = QBCore.Functions.GetPlayerData()
+    PlayerJob = playerData.job or {}
+    if not isPolice() then return end
+
+    local vehicleType = data and data.type or 'patrol'
+    local spawnIndex = data and data.spawnIndex or 1
+    local vehicles = getVehiclesForType(vehicleType)
+
+    if #vehicles == 0 then
+        QBCore.Functions.Notify('No vehicles available for your rank', 'error')
+        return
+    end
+
+    local menu = {
+        {
+            header = ('%s Garage'):format(vehicleType:gsub('^%l', string.upper)),
+            isMenuHeader = true
+        }
+    }
+
+    for _, info in ipairs(vehicles) do
+        menu[#menu + 1] = {
+            header = info.label or info.model,
+            txt = ('Model: %s'):format(info.model),
+            params = {
+                event = 'police:client:SpawnGarageVehicle',
+                args = {
+                    type = vehicleType,
+                    model = info.model,
+                    spawnIndex = spawnIndex,
+                    extras = info.extras,
+                    livery = info.livery,
+                    fuel = info.fuel
+                }
+            }
+        }
+    end
+
+    menu[#menu + 1] = {
+        header = 'Close',
+        params = { event = 'qb-menu:client:closeMenu' }
+    }
+
+    exports['qb-menu']:openMenu(menu)
+end)
+
+RegisterNetEvent('police:client:HandleHeliMenu', function(data)
+    local playerData = QBCore.Functions.GetPlayerData()
+    PlayerJob = playerData.job or {}
+    if not isPolice() then return end
+
+    local grade = PlayerJob.grade and PlayerJob.grade.level or 0
+    local options = {}
+    for requiredGrade, helicopters in pairs(Config.AuthorizedHelicopters or {}) do
+        if grade >= requiredGrade then
+            for _, info in ipairs(helicopters) do
+                options[#options + 1] = info
+            end
+        end
+    end
+
+    if #options == 0 then
+        QBCore.Functions.Notify('You are not cleared for air support', 'error')
+        return
+    end
+
+    local menu = {
+        {
+            header = 'Helicopter Hangar',
+            isMenuHeader = true
+        }
+    }
+
+    for _, info in ipairs(options) do
+        menu[#menu + 1] = {
+            header = info.label or info.model,
+            txt = ('Model: %s'):format(info.model),
+            params = {
+                event = 'police:client:SpawnHelicopter',
+                args = {
+                    model = info.model,
+                    spawnIndex = data and data.spawnIndex or 1,
+                    extras = info.extras,
+                    livery = info.livery,
+                    fuel = info.fuel
+                }
+            }
+        }
+    end
+
+    menu[#menu + 1] = {
+        header = 'Close',
+        params = { event = 'qb-menu:client:closeMenu' }
+    }
+
+    exports['qb-menu']:openMenu(menu)
+end)
+
+RegisterNetEvent('police:client:SpawnGarageVehicle', function(data)
+    if not data or not data.model then return end
+    TriggerServerEvent('police:server:SpawnVehicle', data)
+end)
+
+RegisterNetEvent('police:client:SpawnHelicopter', function(data)
+    if not data or not data.model then return end
+    TriggerServerEvent('police:server:SpawnHelicopter', data)
+end)

--- a/backend/fivem/police_job/client/main.lua
+++ b/backend/fivem/police_job/client/main.lua
@@ -1,0 +1,267 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local PlayerJob = {}
+local onDuty = false
+local createdZones = {}
+
+local function isOnPoliceDuty()
+    return PlayerJob.name == Config.JobName and onDuty
+end
+
+local function clearTargetZones()
+    if not Config.UseTarget then return end
+    for name in pairs(createdZones) do
+        exports['qb-target']:RemoveZone(name)
+    end
+    createdZones = {}
+end
+
+local function addBoxZone(name, coords, length, width, options)
+    if not Config.UseTarget then return end
+    length = length or 1.0
+    width = width or 1.0
+    local heading = coords.w or 0.0
+    local position = vector3(coords.x, coords.y, coords.z)
+    exports['qb-target']:RemoveZone(name)
+    exports['qb-target']:AddBoxZone(name, position, length, width, {
+        name = name,
+        heading = heading,
+        minZ = coords.z - 1.0,
+        maxZ = coords.z + 1.0,
+        debugPoly = false
+    }, {
+        options = options,
+        distance = 2.5
+    })
+    createdZones[name] = true
+end
+
+local function setupTargets()
+    clearTargetZones()
+    if PlayerJob.name ~= Config.JobName or not Config.UseTarget then return end
+
+    for index, coords in ipairs(Config.Locations.duty or {}) do
+        addBoxZone(('police-duty-%s'):format(index), coords, 1.6, 1.6, {
+            {
+                type = 'client',
+                event = 'police:client:ToggleDuty',
+                icon = 'fas fa-clock',
+                label = 'Toggle Duty'
+            }
+        })
+    end
+
+    for index, data in ipairs(Config.Locations.vehicle or {}) do
+        addBoxZone(('police-vehicle-%s'):format(index), data.coords, 5.0, 6.0, {
+            {
+                type = 'client',
+                event = 'police:client:OpenVehicleGarage',
+                icon = 'fas fa-car',
+                label = 'Police Garage',
+                args = {
+                    type = data.type or 'patrol',
+                    spawnIndex = index
+                }
+            }
+        })
+    end
+
+    for index, data in ipairs(Config.Locations.helicopter or {}) do
+        addBoxZone(('police-heli-%s'):format(index), data.coords, 5.0, 5.0, {
+            {
+                type = 'client',
+                event = 'police:client:OpenHelicopterGarage',
+                icon = 'fas fa-helicopter',
+                label = 'Helicopter Garage',
+                args = { spawnIndex = index }
+            }
+        })
+    end
+
+    for index, coords in ipairs(Config.Locations.stash or {}) do
+        addBoxZone(('police-stash-%s'):format(index), coords, 1.4, 1.4, {
+            {
+                type = 'client',
+                event = 'police:client:OpenPersonalLocker',
+                icon = 'fas fa-box-open',
+                label = 'Open Locker'
+            }
+        })
+    end
+
+    for index, coords in ipairs(Config.Locations.armory or {}) do
+        addBoxZone(('police-armory-%s'):format(index), coords, 1.6, 1.6, {
+            {
+                type = 'client',
+                event = 'police:client:OpenArmory',
+                icon = 'fas fa-warehouse',
+                label = 'Open Armory'
+            }
+        })
+    end
+
+    for index, coords in ipairs(Config.Locations.trash or {}) do
+        addBoxZone(('police-trash-%s'):format(index), coords, 1.4, 1.4, {
+            {
+                type = 'client',
+                event = 'police:client:OpenTrash',
+                icon = 'fas fa-dumpster',
+                label = 'Open Trash'
+            }
+        })
+    end
+
+    for index, coords in ipairs(Config.Locations.fingerprint or {}) do
+        addBoxZone(('police-fingerprint-%s'):format(index), coords, 1.4, 1.4, {
+            {
+                type = 'client',
+                event = 'police:client:UseFingerprint',
+                icon = 'fas fa-fingerprint',
+                label = 'Fingerprint Scanner'
+            }
+        })
+    end
+
+    for index, data in ipairs(Config.Locations.evidence or {}) do
+        addBoxZone(('police-evidence-%s'):format(index), data.coords, 1.4, 1.4, {
+            {
+                type = 'client',
+                event = 'police:client:OpenEvidence',
+                icon = 'fas fa-archive',
+                label = ('Evidence Locker %s'):format(data.stash),
+                args = { stash = data.stash }
+            }
+        })
+    end
+end
+
+local function ensureDutyState()
+    if PlayerJob.name == Config.JobName then
+        onDuty = PlayerJob.onduty
+        if Config.DefaultDuty and not onDuty then
+            TriggerServerEvent('QBCore:ToggleDuty')
+        end
+    end
+end
+
+local function handleJobUpdate(jobInfo)
+    PlayerJob = jobInfo
+    ensureDutyState()
+    setupTargets()
+end
+
+local function initJob()
+    local playerData = QBCore.Functions.GetPlayerData()
+    if playerData and playerData.job then
+        PlayerJob = playerData.job
+        onDuty = playerData.job.onduty
+        setupTargets()
+        ensureDutyState()
+    end
+end
+
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+    initJob()
+end)
+
+RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
+    clearTargetZones()
+    PlayerJob = {}
+    onDuty = false
+end)
+
+RegisterNetEvent('QBCore:Client:OnJobUpdate', function(jobInfo)
+    handleJobUpdate(jobInfo)
+end)
+
+RegisterNetEvent('QBCore:Client:SetDuty', function(duty)
+    onDuty = duty
+end)
+
+RegisterNetEvent('police:client:ToggleDuty', function()
+    if PlayerJob.name ~= Config.JobName then return end
+    TriggerServerEvent('QBCore:ToggleDuty')
+end)
+
+RegisterNetEvent('police:client:OpenPersonalLocker', function()
+    if not isOnPoliceDuty() then return end
+    TriggerServerEvent('police:server:OpenLocker')
+end)
+
+RegisterNetEvent('police:client:OpenArmory', function()
+    if not isOnPoliceDuty() then return end
+    TriggerServerEvent('police:server:OpenArmory')
+end)
+
+RegisterNetEvent('police:client:OpenTrash', function()
+    if not isOnPoliceDuty() then return end
+    TriggerServerEvent('police:server:OpenTrash')
+end)
+
+RegisterNetEvent('police:client:OpenEvidence', function(data)
+    if not isOnPoliceDuty() then return end
+    if not data or not data.stash then return end
+    TriggerServerEvent('police:server:OpenEvidence', data.stash)
+end)
+
+RegisterNetEvent('police:client:UseFingerprint', function()
+    if not isOnPoliceDuty() then return end
+    local player, distance = QBCore.Functions.GetClosestPlayer()
+    if player ~= -1 and distance <= 2.0 then
+        QBCore.Functions.Progressbar('scan-fingerprint', 'Scanning fingerprint...', Config.FingerprintWait, false, true, {
+            disableMovement = true,
+            disableCarMovement = true,
+            disableMouse = false,
+            disableCombat = true
+        }, {}, {}, {}, function()
+            local targetId = GetPlayerServerId(player)
+            TriggerServerEvent('police:server:ShowFingerprint', targetId)
+        end)
+    else
+        QBCore.Functions.Notify('No suspect nearby', 'error')
+    end
+end)
+
+RegisterNetEvent('police:client:OpenVehicleGarage', function(data)
+    TriggerEvent('police:client:HandleGarageMenu', data)
+end)
+
+RegisterNetEvent('police:client:OpenHelicopterGarage', function(data)
+    TriggerEvent('police:client:HandleHeliMenu', data)
+end)
+
+RegisterNetEvent('police:client:VehicleSpawned', function(netId, meta)
+    if not netId or netId == 0 then return end
+    local veh = NetToVeh(netId)
+    if not DoesEntityExist(veh) then return end
+    SetVehicleEngineOn(veh, true, true, false)
+    SetVehicleDirtLevel(veh, 0.0)
+    if meta then
+        if meta.fuel then
+            if not pcall(function() exports['LegacyFuel']:SetFuel(veh, meta.fuel) end) then
+                pcall(function() exports['cdn-fuel']:SetFuel(veh, meta.fuel) end)
+            end
+        end
+        if meta.livery then
+            SetVehicleLivery(veh, meta.livery)
+        end
+        if meta.extras then
+            for extraId, enabled in pairs(meta.extras) do
+                SetVehicleExtra(veh, tonumber(extraId), not enabled)
+            end
+        end
+    end
+end)
+
+RegisterNetEvent('police:client:ShowFingerprint', function(data)
+    if data and data.fingerprint then
+        QBCore.Functions.Notify(('Fingerprint match: %s'):format(data.fingerprint), 'primary', 7500)
+    else
+        QBCore.Functions.Notify('Fingerprint scan inconclusive', 'error', 5000)
+    end
+end)
+
+CreateThread(function()
+    Wait(1000)
+    initJob()
+end)

--- a/backend/fivem/police_job/config.lua
+++ b/backend/fivem/police_job/config.lua
@@ -1,0 +1,109 @@
+Config = {}
+
+Config.JobName = 'police'
+Config.DefaultDuty = true
+Config.UseTarget = true
+Config.HandcuffTimerEnabled = true
+Config.HandcuffTimer = 10 * 60000 -- 10 minutes
+Config.EvidenceStashWeight = 400000
+Config.EvidenceStashSlots = 50
+Config.LockerStashWeight = 300000
+Config.LockerStashSlots = 40
+Config.ArmoryStashWeight = 250000
+Config.ArmoryStashSlots = 60
+Config.TrashStashWeight = 60000
+Config.TrashStashSlots = 30
+Config.FingerprintWait = 4000
+Config.MinBail = 200
+Config.MaxBail = 5000
+
+Config.WhitelistedRadioChannels = {
+    [1] = true,
+    [2] = true,
+    [3] = true,
+    [4] = true,
+    [5] = true
+}
+
+Config.AuthorizedVehicles = {
+    patrol = {
+        [0] = {
+            { model = 'police', label = 'Vapid Police Cruiser', livery = 0, fuel = 100 },
+            { model = 'police3', label = 'Police Interceptor', livery = 0, fuel = 100 }
+        },
+        [2] = {
+            { model = 'police4', label = 'Undercover Buffalo', livery = 0, fuel = 100 }
+        },
+        [3] = {
+            { model = 'fbi', label = 'FIB Buffalo', livery = 0, fuel = 100 }
+        }
+    },
+    traffic = {
+        [1] = {
+            { model = 'police2', label = 'Vapid Buffalo S', livery = 0, fuel = 100 }
+        },
+        [3] = {
+            { model = 'policeb', label = 'Police Bike', livery = 0, fuel = 100 }
+        }
+    }
+}
+
+Config.AuthorizedHelicopters = {
+    [2] = {
+        { model = 'polmav', label = 'Police Maverick', livery = 0, fuel = 100 }
+    }
+}
+
+Config.AuthorizedArmory = {
+    [0] = {
+        { name = 'weapon_stungun', label = 'Taser', type = 'weapon', price = 0 },
+        { name = 'weapon_nightstick', label = 'Nightstick', type = 'weapon', price = 0 },
+        { name = 'pistol_ammo', label = '9mm Ammo', type = 'item', amount = 5, price = 0 }
+    },
+    [1] = {
+        { name = 'weapon_combatpistol', label = 'Combat Pistol', type = 'weapon', price = 0 },
+        { name = 'armor', label = 'Body Armor', type = 'item', amount = 2, price = 0 }
+    },
+    [2] = {
+        { name = 'weapon_carbinerifle', label = 'Carbine Rifle', type = 'weapon', price = 0 },
+        { name = 'rifle_ammo', label = '5.56 Ammo', type = 'item', amount = 5, price = 0 }
+    }
+}
+
+Config.Locations = {
+    duty = {
+        vector4(441.13, -981.04, 30.69, 90.0),
+        vector4(1851.21, 3689.51, 34.27, 210.87)
+    },
+    vehicle = {
+        { coords = vector4(445.85, -986.67, 25.7, 89.5), type = 'patrol' },
+        { coords = vector4(452.06, -1018.41, 28.45, 90.0), type = 'traffic' }
+    },
+    helicopter = {
+        { coords = vector4(449.68, -981.24, 43.69, 87.19) }
+    },
+    stash = {
+        vector4(452.35, -995.7, 30.69, 178.0)
+    },
+    armory = {
+        vector4(481.93, -995.34, 30.69, 93.92)
+    },
+    trash = {
+        vector4(456.24, -988.41, 24.7, 180.0)
+    },
+    fingerprint = {
+        vector4(473.08, -1007.43, 26.27, 90.0)
+    },
+    evidence = {
+        { stash = '1', coords = vector4(475.01, -996.32, 26.27, 91.53) },
+        { stash = '2', coords = vector4(473.16, -996.34, 26.27, 270.93) }
+    },
+    impound = {
+        vector3(436.18, -996.73, 25.45)
+    },
+    jail = {
+        exit = vector4(1775.5, 2593.48, 45.72, 269.91),
+        yard = vector4(1764.05, 2569.9, 45.57, 91.02)
+    }
+}
+

--- a/backend/fivem/police_job/fxmanifest.lua
+++ b/backend/fivem/police_job/fxmanifest.lua
@@ -1,0 +1,32 @@
+fx_version 'cerulean'
+
+game 'gta5'
+
+description 'QB-Style Police Job'
+
+author 'RouteFlow London Test Conversion'
+
+version '1.0.0'
+
+shared_script 'config.lua'
+
+client_scripts {
+    '@PolyZone/client.lua',
+    '@PolyZone/BoxZone.lua',
+    '@PolyZone/ComboZone.lua',
+    'client/main.lua',
+    'client/garage.lua',
+    'client/evidence.lua'
+}
+
+server_scripts {
+    '@oxmysql/lib/MySQL.lua',
+    'server/main.lua'
+}
+
+dependencies {
+    'qb-core',
+    'qb-target',
+    'qb-menu',
+    'qb-input'
+}

--- a/backend/fivem/police_job/server/main.lua
+++ b/backend/fivem/police_job/server/main.lua
@@ -1,0 +1,213 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local function isPolice(Player)
+    return Player and Player.PlayerData.job and Player.PlayerData.job.name == Config.JobName
+end
+
+local function isOnDuty(Player)
+    return isPolice(Player) and Player.PlayerData.job.onduty
+end
+
+local function openStash(src, stashId, label, weight, slots)
+    exports['qb-inventory']:CreateStash(stashId, label, slots, weight)
+    TriggerClientEvent('inventory:client:OpenInventory', src, 'stash', stashId, {
+        maxweight = weight,
+        slots = slots
+    })
+    TriggerClientEvent('inventory:client:SetCurrentStash', src, stashId)
+end
+
+local function getAuthorizedVehicle(vehicleType, grade, model)
+    local pool = Config.AuthorizedVehicles[vehicleType]
+    if not pool then return nil end
+
+    local selected
+    for requiredGrade, vehicles in pairs(pool) do
+        if grade >= requiredGrade then
+            for _, info in ipairs(vehicles) do
+                if info.model == model then
+                    selected = info
+                end
+            end
+        end
+    end
+    return selected
+end
+
+local function giveVehicleKeys(src, plate)
+    TriggerClientEvent('vehiclekeys:client:SetOwner', src, plate)
+    if GetResourceState('qb-vehiclekeys') == 'started' then
+        pcall(function()
+            exports['qb-vehiclekeys']:SetVehicleKey(plate, true)
+        end)
+    end
+end
+
+RegisterNetEvent('police:server:OpenLocker', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+
+    local stashId = ('police_locker_%s'):format(Player.PlayerData.citizenid)
+    openStash(src, stashId, 'Personal Locker', Config.LockerStashWeight, Config.LockerStashSlots)
+end)
+
+RegisterNetEvent('police:server:OpenArmory', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+
+    openStash(src, 'police_armory', 'Police Armory', Config.ArmoryStashWeight, Config.ArmoryStashSlots)
+end)
+
+RegisterNetEvent('police:server:OpenTrash', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+
+    openStash(src, 'police_trash', 'Police Trash', Config.TrashStashWeight, Config.TrashStashSlots)
+end)
+
+RegisterNetEvent('police:server:OpenEvidence', function(stashId)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+    if not stashId then return end
+
+    local stash = ('police_evidence_%s'):format(stashId)
+    openStash(src, stash, ('Evidence Locker %s'):format(stashId), Config.EvidenceStashWeight, Config.EvidenceStashSlots)
+end)
+
+RegisterNetEvent('police:server:CreateEvidenceBag', function(metadata)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+
+    metadata = metadata or {}
+    metadata.officer = Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname
+    metadata.callsign = Player.PlayerData.metadata and Player.PlayerData.metadata['callsign'] or '000'
+
+    if Player.Functions.AddItem('evidencebag', 1, false, metadata) then
+        TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['evidencebag'], 'add')
+    else
+        TriggerClientEvent('QBCore:Notify', src, 'Inventory full', 'error')
+    end
+end)
+
+RegisterNetEvent('police:server:UpdateBodycamLog', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+
+    Player.Functions.SetMetaData('bodycam', os.time())
+end)
+
+RegisterNetEvent('police:server:ShowFingerprint', function(targetId)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+
+    local Target = QBCore.Functions.GetPlayer(targetId)
+    if not Target then
+        TriggerClientEvent('QBCore:Notify', src, 'No person nearby to scan', 'error')
+        return
+    end
+
+    local fingerprint = Target.PlayerData.metadata and (Target.PlayerData.metadata['fingerprint'] or Target.PlayerData.citizenid) or Target.PlayerData.citizenid
+    TriggerClientEvent('police:client:ShowFingerprint', src, {
+        fingerprint = fingerprint,
+        citizenid = Target.PlayerData.citizenid,
+        name = string.format('%s %s', Target.PlayerData.charinfo.firstname, Target.PlayerData.charinfo.lastname)
+    })
+end)
+
+RegisterNetEvent('police:server:SpawnVehicle', function(data)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+    if not data or not data.model or not data.spawnIndex then return end
+
+    local spawnConfig = Config.Locations.vehicle[data.spawnIndex]
+    if not spawnConfig then return end
+
+    local grade = Player.PlayerData.job.grade.level
+    local info = getAuthorizedVehicle(data.type or spawnConfig.type or 'patrol', grade, data.model)
+    if not info then
+        TriggerClientEvent('QBCore:Notify', src, 'You are not authorized to take this vehicle', 'error')
+        return
+    end
+
+    local coords = spawnConfig.coords
+    QBCore.Functions.SpawnVehicle(src, info.model, coords, coords.w, function(veh)
+        if not veh then return end
+        local plate = data.plate or ('POL' .. math.random(100, 999))
+        SetVehicleNumberPlateText(veh, plate)
+        SetVehicleDirtLevel(veh, 0.0)
+        giveVehicleKeys(src, plate)
+        local netId = NetworkGetNetworkIdFromEntity(veh)
+        TriggerClientEvent('police:client:VehicleSpawned', src, netId, info)
+    end, true)
+end)
+
+RegisterNetEvent('police:server:SpawnHelicopter', function(data)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not isOnDuty(Player) then return end
+    if not data or not data.model or not data.spawnIndex then return end
+
+    local spawnConfig = Config.Locations.helicopter[data.spawnIndex]
+    if not spawnConfig then return end
+
+    local grade = Player.PlayerData.job.grade.level
+    local authorized = false
+    local selectedInfo
+    for requiredGrade, helicopters in pairs(Config.AuthorizedHelicopters or {}) do
+        if grade >= requiredGrade then
+            for _, info in ipairs(helicopters) do
+                if info.model == data.model then
+                    authorized = true
+                    selectedInfo = info
+                end
+            end
+        end
+    end
+
+    if not authorized then
+        TriggerClientEvent('QBCore:Notify', src, 'You are not cleared for this aircraft', 'error')
+        return
+    end
+
+    local coords = spawnConfig.coords
+    QBCore.Functions.SpawnVehicle(src, selectedInfo.model, coords, coords.w, function(veh)
+        if not veh then return end
+        local plate = data.plate or ('AIR' .. math.random(100, 999))
+        SetVehicleNumberPlateText(veh, plate)
+        SetVehicleDirtLevel(veh, 0.0)
+        giveVehicleKeys(src, plate)
+        local netId = NetworkGetNetworkIdFromEntity(veh)
+        TriggerClientEvent('police:client:VehicleSpawned', src, netId, selectedInfo)
+    end, true)
+end)
+
+QBCore.Functions.CreateCallback('police:server:IsWhitelistedChannel', function(_, cb, channel)
+    cb(Config.WhitelistedRadioChannels[channel] == true)
+end)
+
+QBCore.Functions.CreateCallback('police:server:GetArmoryItems', function(source, cb)
+    local Player = QBCore.Functions.GetPlayer(source)
+    if not isOnDuty(Player) then
+        cb({})
+        return
+    end
+
+    local grade = Player.PlayerData.job.grade.level
+    local items = {}
+    for requiredGrade, gradeItems in pairs(Config.AuthorizedArmory or {}) do
+        if grade >= requiredGrade then
+            for _, item in ipairs(gradeItems) do
+                items[#items + 1] = item
+            end
+        end
+    end
+    cb(items)
+end)


### PR DESCRIPTION
## Summary
- rework the police job fxmanifest to rely on qb-core dependencies and streamlined client/server entrypoints
- replace the configuration with qb-style job settings, vehicle authorizations, and interaction locations to mirror qb-policejob expectations
- implement qb-target driven client interactions, garage menus, evidence handling, and matching server-side stash/vehicle logic for the police job

## Testing
- No automated tests (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3938ef62483229dea7e0a7008dc7a