### PR TITLE
Replace newsletter form with Mailjet embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,12 +228,31 @@
         <h2>Stay ahead of the next service change</h2>
         <p>We only send high-signal updates: new datasets, layout upgrades and travel literacy packs.</p>
       </div>
-      <form id="newsletter-form" class="landing-updates__form" novalidate>
-        <label for="email" class="sr-only">Email address</label>
-        <input type="email" id="email" placeholder="Enter your email" required />
-        <button type="submit">Subscribe</button>
-        <p class="landing-updates__response" id="response-message" aria-live="polite"></p>
-      </form>
+      <div class="landing-updates__form">
+        <iframe
+          data-w-token="3bb4115e41c545cc2d79"
+          data-w-type="pop-in"
+          frameborder="0"
+          scrolling="yes"
+          marginheight="0"
+          marginwidth="0"
+          src="https://1xl3t.mjt.lu/wgt/1xl3t/0pom/form?c=c8d5af69"
+          width="100%"
+          style="height: 0;"
+        ></iframe>
+        <iframe
+          data-w-token="3bb4115e41c545cc2d79"
+          data-w-type="trigger"
+          frameborder="0"
+          scrolling="no"
+          marginheight="0"
+          marginwidth="0"
+          src="https://1xl3t.mjt.lu/wgt/1xl3t/0pom/trigger?c=488ee8a4"
+          width="100%"
+          style="height: 0;"
+        ></iframe>
+        <script type="text/javascript" src="https://app.mailjet.com/pas-nc-pop-in-v1.js"></script>
+      </div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- replace the landing newsletter form with the provided Mailjet embed code
- include the Mailjet script to activate the embedded pop-in and trigger iframes

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e24d5a914c8322bf42c9da056b8fd6