### PR TITLE
Use relative base path for Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   server: {
     open: true
   }


### PR DESCRIPTION
## Summary
- configure Vite to emit relative asset URLs so the app loads when hosted from a subdirectory

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d1090bc083208a16ac6944133168)